### PR TITLE
obtain-sensor-data

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 
+[*.json]
+indent_size = 3
+
 [*.bat]
 indent_style = tab
 end_of_line = crlf

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,12 +79,10 @@ Ready to contribute? Here's how to set up `nexia` for local development.
 5. When you're done making changes, check that your changes pass flake8 and the
    tests, including testing other Python versions with tox::
 
-    $ flake8 nexia tests
     $ pip install -r requirements_tests.txt
+    $ flake8 nexia tests
     $ pytest --cov --cov-report term-missing
     $ tox
-
-   To get flake8 and tox, just pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -80,7 +80,8 @@ Ready to contribute? Here's how to set up `nexia` for local development.
    tests, including testing other Python versions with tox::
 
     $ flake8 nexia tests
-    $ python setup.py test or pytest
+    $ pip install -r requirements_tests.txt
+    $ pytest --cov --cov-report term-missing
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.

--- a/README.md
+++ b/README.md
@@ -18,61 +18,71 @@ Not supported XL624, others
 
 By connecting this component, you will have access to all thermostats and zones in your associated home.
 
-### Concepts 
+### Concepts
 
 The Nexia Thermostat supports the following key concepts.
 
+#### Sensors
 
+You can obtain sensor details in a Nexia Thermostat environment.
+The sensor data loaded during Nexia Home update are often out of date.
+So the Nexia Thermostat Zone service `load_current_sensor_state`
+is provided to load current sensor state into the physical thermostat.
+Many existing thermostat instance services will refresh this sensor data before completing.
+If no such service is desired,
+the Nexia Thermostat service `refresh_thermostat_data` is provided to refresh instance data.
+The Nexia Thermostat Zone service `get_sensors` is provided to obtain these
+sensor data in a list of sensor detail data objects of type NexiaSensor.
 
-## Attributes 
+## Attributes
 
 The following attributes are provided by the Nexia Thermostat
-`aux_heat`, `away_mode`, `current_humidity`, `current_temperature`, 
-`fan_list`, `fan_mode`, `firmware`, `friendly_name`, `hold_mode`, `humidity`, `humidify_supported`, 
+`aux_heat`, `away_mode`, `current_humidity`, `current_temperature`,
+`fan_list`, `fan_mode`, `firmware`, `friendly_name`, `hold_mode`, `humidity`, `humidify_supported`,
 `dehumidify_supported`, `humidify_setpoint`, `dehumidify_setpoint`
-`max_humidity`, `max_temp`, `min_humidity`, `min_temp`, `model`, `operation_list`, 
-`operation_mode`, `setpoint_status`, `target_temp_high`, `target_temp_low`, 
-`target_temp_step`, `temperature`, `thermostat_id`, `thermostat_name`, `zone_id`, 
+`max_humidity`, `max_temp`, `min_humidity`, `min_temp`, `model`, `operation_list`,
+`operation_mode`, `setpoint_status`, `target_temp_high`, `target_temp_low`,
+`target_temp_step`, `temperature`, `thermostat_id`, `thermostat_name`, `zone_id`,
 `zone_status`
 
-### `aux_heat` 
+### `aux_heat`
 
-Indicates whether or not aux heat / emergency heat is enabled. 
+Indicates whether or not aux heat / emergency heat is enabled.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | 'on' or 'off' |
 
 ### `away_mode`
 
-Indicates whether the 'away' preset is selected. 
+Indicates whether the 'away' preset is selected.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | 'on' or 'off' |
 
 ### Attribute `current_humidity`
 
-Provides you with the main thermostat's relative humidity. Outdoor humidity or zone specific 
-humidity is not currently available via Nexia's published data. 
+Provides you with the main thermostat's relative humidity. Outdoor humidity or zone specific
+humidity is not currently available via Nexia's published data.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Float | current humidity |
 
 ### Attribute `current_temperature`
 
-Provides you with the current zone's temperature. 
+Provides you with the current zone's temperature.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | current temperature |
 
 ### Attribute `fan_list`
 
-This is a list of all available fan modes you can select, separated by commas. 
+This is a list of all available fan modes you can select, separated by commas.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | 'auto,on,circulate' |
 
@@ -80,7 +90,7 @@ This is a list of all available fan modes you can select, separated by commas.
 
 The currently selected fan mode.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | 'auto', 'on', or 'circulate' |
 
@@ -88,67 +98,67 @@ The currently selected fan mode.
 
 Provides you with the current firmware version of the main thermostat.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | firmware version |
 
 ### Attribute `hold_mode`
 
-Indicates if a hold is currently in place on this zone. Examples of such are 'away', 
+Indicates if a hold is currently in place on this zone. Examples of such are 'away',
 'home', 'sleep', or 'evening'
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | hold mode |
 
 ### Attribute `humidity`
 
-The target dehumidify set point (%) of the system. 
+The target dehumidify set point (%) of the system.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | dehumidify setpoint as an integer |
 
 ### Attribute `humidify_supported`
 
-Indicates if the system supports humidification. 
+Indicates if the system supports humidification.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Boolean | humidification supported |
 
 ### Attribute `dehumidify_supported`
 
-Indicates if the system supports dehumidification. 
+Indicates if the system supports dehumidification.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Boolean | dehumidification supported |
 
 
 ### Attribute `humidify_setpoint`
 
-The target humidify set point (%) of the system. 
+The target humidify set point (%) of the system.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | humidify setpoint as an integer |
 
 
 ### Attribute `dehumidify_setpoint`
 
-Same as `humidity` The target dehumidify set point (%) of the system. 
+Same as `humidity` The target dehumidify set point (%) of the system.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | dehumidify setpoint as an integer |
 
 
 ### Attribute `max_humidity`
 
-Hard-coded value indicating the maximum dehumidify set point (%) you can set, as an integer.  
+Hard-coded value indicating the maximum dehumidify set point (%) you can set, as an integer.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | maximum humidity set point, always 65 |
 
@@ -156,15 +166,15 @@ Hard-coded value indicating the maximum dehumidify set point (%) you can set, as
 
 The maximum temperature set point of the zone. This can change based on the thermostat's settings.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | maximum temperature, such as 90 |
 
 ### Attribute `min_humidity`
 
-Hard-coded value indicating the minimum dehumidify set point (%) you can set, as an integer.  
+Hard-coded value indicating the minimum dehumidify set point (%) you can set, as an integer.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | minimum humidity set point, always 35  |
 
@@ -172,7 +182,7 @@ Hard-coded value indicating the minimum dehumidify set point (%) you can set, as
 
 The minimum temperature set point of the zone. This can change based on the thermostat's settings.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | minimum temperature, such as 55 |
 
@@ -180,7 +190,7 @@ The minimum temperature set point of the zone. This can change based on the ther
 
 The thermostat model, such as 'TZON1050AC52ZAA'
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | thermostat model |
 
@@ -188,7 +198,7 @@ The thermostat model, such as 'TZON1050AC52ZAA'
 
 List of available operation modes such as 'AUTO,COOL,HEAT,OFF'
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | operation modes |
 
@@ -196,24 +206,24 @@ List of available operation modes such as 'AUTO,COOL,HEAT,OFF'
 
 The current operation mode, such as 'AUTO', 'COOL', 'HEAT', or 'OFF'
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | operation mode |
 
 ### Attribute `setpoint_status`
 
-This provides you with a system set point status, such as 'Holding Permanently', 
-'Following Schedule - Away', or 'Following Schedule - Home'. This is not an exhaustive list. 
+This provides you with a system set point status, such as 'Holding Permanently',
+'Following Schedule - Away', or 'Following Schedule - Home'. This is not an exhaustive list.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | set point status |
 
 ### Attribute `target_temp_high`
 
-The target cooling (upper-bound) temperature for the current zone. 
+The target cooling (upper-bound) temperature for the current zone.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | upper-bound target temperature |
 
@@ -221,51 +231,51 @@ The target cooling (upper-bound) temperature for the current zone.
 
 The target heating (lower-bound) temperature for the current zone.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | lower-bound target temperature |
 
 ### Attribute `target_temp_step`
 
-The step at which the temperature can be increased or decreased. For Fahrenheit, 
+The step at which the temperature can be increased or decreased. For Fahrenheit,
 this is 1.0 degrees per step, and for Celsius, this is 0.5 degrees per step.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Float | step |
 
 ### Attribute `temperature`
 
-Based on the current system mode, this is the target temperature for the zone. 
+Based on the current system mode, this is the target temperature for the zone.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | target temperature |
- 
+
 ### Attribute `thermostat_id`
 
 This is the main thermostat's ID, here for reference. This will match up with the 'id'
 in the JSON data provided by Nexia.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | thermostat ID |
 
 ### Attribute `thermostat_name`
 
 The name of the system. This will be shared across all zones of your Trane / American Standard
-system. 
+system.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | thermostat name|
 
 ### Attribute `zone_id`
 
-The zone ID for this particular zone, here for reference. This will match up with the 'id' 
-in the JSON data provided by Nexia under the 'zones' list. 
+The zone ID for this particular zone, here for reference. This will match up with the 'id'
+in the JSON data provided by Nexia under the 'zones' list.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | zone ID |
 
@@ -273,15 +283,32 @@ in the JSON data provided by Nexia under the 'zones' list.
 
 The status of the zone, such as 'Cooling', or 'Heating"
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | zone status |
- 
- 
+
+
+## NexiaHome Attributes
+
+The following attribute is provided by the Nexia Home:
+`log_response`
+
+### Attribute `log_response`
+
+An instance attribute of NexiaHome that controls logging http response text.
+This can be True or False.
+It is initialized to False and you can change it to
+True when you want to collect http response text in your logs.
+
+| Attribute type | Description              |
+|----------------|--------------------------|
+| Boolean        | response logging control |
+
+
 ## Services
 
 The following `climate` services are provided by the Nexia Thermostat:
-`set_aux_heat`, `set_away_mode`, `set_fan_mode`, `set_hold_mode`, `set_humidity`, 
+`set_aux_heat`, `set_away_mode`, `set_fan_mode`, `set_hold_mode`, `set_humidity`,
 `set_operation_mode`, `set_temperature`, `turn_on`, `turn_off`
 
 The service `set_swing_mode` offered by the [Climate component](/components/climate/)
@@ -289,6 +316,16 @@ is not implemented for this thermostat.
 
 The following `nexia` climate service is provided by the Nexia Thermostat:
 `set_aircleaner_mode`
+
+The following additional service is provided by the Nexia Thermostat:
+`refresh_thermostat_data`
+
+### Service `refresh_thermostat_data`
+
+Refresh data in this thermostat instance.
+Note: Many other services refresh this data before completing,
+so you may not need to call this service to get fresh data.
+No arguments are passed to this service.
 
 ### Service `set_aux_heat`
 
@@ -310,7 +347,7 @@ Turns the away mode on or off for the thermostat.
 
 ### Service `set_fan_mode`
 
-Sets the fan mode for the system. See the `fan_list` attribute for options. This is a system-wide setting. 
+Sets the fan mode for the system. See the `fan_list` attribute for options. This is a system-wide setting.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -336,7 +373,7 @@ Sets the dehumidify set point of the system. Range from 35-65. This is a system-
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
-| `humidity` | no | The dehumidify setpoint, like 50.  
+| `humidity` | no | The dehumidify setpoint, like 50.
 
 ### Service `set_temperature`
 
@@ -354,7 +391,7 @@ be provided.
 
 ### Service `set_operation_mode`
 
-Sets the current operation mode of the thermostat. See attribute `operation_list` for options. 
+Sets the current operation mode of the thermostat. See attribute `operation_list` for options.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -363,7 +400,7 @@ Sets the current operation mode of the thermostat. See attribute `operation_list
 
 ### Service `turn_on`
 
-Turns the zone on. 
+Turns the zone on.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -371,7 +408,7 @@ Turns the zone on.
 
 ### Service `turn_off`
 
-Turns the zone off. 
+Turns the zone off.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -379,8 +416,8 @@ Turns the zone off.
 
 ### Service `set_aircleaner_mode`
 
-Part of the `nexia.` services. Sets the air cleaner mode. Options include 'AUTO', 'QUICK', and 
-'ALLERGY'. This is a system-wide setting. 
+Part of the `nexia.` services. Sets the air cleaner mode. Options include 'AUTO', 'QUICK', and
+'ALLERGY'. This is a system-wide setting.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -389,12 +426,36 @@ Part of the `nexia.` services. Sets the air cleaner mode. Options include 'AUTO'
 
 ### Service `set_humidify_setpoint`
 
-Part of the `nexia.` services. Sets the humidify setpoint. This is a system-wide setting. 
+Part of the `nexia.` services. Sets the humidify setpoint. This is a system-wide setting.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
-| `humidity` | no | Humidify setpoint level, from 35 to 65. 
+| `humidity` | no | Humidify setpoint level, from 35 to 65.
+
+## NexiaThermostatZone Services
+
+The following services are provided by the Nexia Thermostat Zone:
+`get_sensors`, `load_current_sensor_state`
+
+### Service `get_sensors`
+
+Get the sensor detail data objects from this zone instance.
+Provides a list of sensor detail data objects.
+No arguments are passed to this service.
+
+### Service `load_current_sensor_state`
+
+Load the current state of a zone's sensors into the physical thermostat.
+Note: This service does not update data in this zone instance -
+many of the thermostat services do so.
+This service returns a bool indicating if it completed successfully.
+
+| Service data attribute | Optional | Default | Description                                    |
+|------------------------|----------|---------|------------------------------------------------|
+| `polling_delay`        | yes      | 0.7     | seconds to wait before each polling attempt    |
+| `max_polls`            | yes      | 50      | maximum number of times to poll for completion |
+
 
 [code-coverage]: https://codecov.io/gh/bdraco/nexia
 [code-cover-shield]: https://codecov.io/gh/bdraco/nexia/branch/master/graph/badge.svg

--- a/README.md
+++ b/README.md
@@ -18,61 +18,61 @@ Not supported XL624, others
 
 By connecting this component, you will have access to all thermostats and zones in your associated home.
 
-### Concepts 
+### Concepts
 
 The Nexia Thermostat supports the following key concepts.
 
 
 
-## Attributes 
+## Attributes
 
 The following attributes are provided by the Nexia Thermostat
-`aux_heat`, `away_mode`, `current_humidity`, `current_temperature`, 
-`fan_list`, `fan_mode`, `firmware`, `friendly_name`, `hold_mode`, `humidity`, `humidify_supported`, 
+`aux_heat`, `away_mode`, `current_humidity`, `current_temperature`,
+`fan_list`, `fan_mode`, `firmware`, `friendly_name`, `hold_mode`, `humidity`, `humidify_supported`,
 `dehumidify_supported`, `humidify_setpoint`, `dehumidify_setpoint`
-`max_humidity`, `max_temp`, `min_humidity`, `min_temp`, `model`, `operation_list`, 
-`operation_mode`, `setpoint_status`, `target_temp_high`, `target_temp_low`, 
-`target_temp_step`, `temperature`, `thermostat_id`, `thermostat_name`, `zone_id`, 
+`max_humidity`, `max_temp`, `min_humidity`, `min_temp`, `model`, `operation_list`,
+`operation_mode`, `setpoint_status`, `target_temp_high`, `target_temp_low`,
+`target_temp_step`, `temperature`, `thermostat_id`, `thermostat_name`, `zone_id`,
 `zone_status`
 
-### `aux_heat` 
+### `aux_heat`
 
-Indicates whether or not aux heat / emergency heat is enabled. 
+Indicates whether or not aux heat / emergency heat is enabled.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | 'on' or 'off' |
 
 ### `away_mode`
 
-Indicates whether the 'away' preset is selected. 
+Indicates whether the 'away' preset is selected.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | 'on' or 'off' |
 
 ### Attribute `current_humidity`
 
-Provides you with the main thermostat's relative humidity. Outdoor humidity or zone specific 
-humidity is not currently available via Nexia's published data. 
+Provides you with the main thermostat's relative humidity. Outdoor humidity or zone specific
+humidity is not currently available via Nexia's published data.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Float | current humidity |
 
 ### Attribute `current_temperature`
 
-Provides you with the current zone's temperature. 
+Provides you with the current zone's temperature.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | current temperature |
 
 ### Attribute `fan_list`
 
-This is a list of all available fan modes you can select, separated by commas. 
+This is a list of all available fan modes you can select, separated by commas.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | 'auto,on,circulate' |
 
@@ -80,7 +80,7 @@ This is a list of all available fan modes you can select, separated by commas.
 
 The currently selected fan mode.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | 'auto', 'on', or 'circulate' |
 
@@ -88,67 +88,67 @@ The currently selected fan mode.
 
 Provides you with the current firmware version of the main thermostat.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | firmware version |
 
 ### Attribute `hold_mode`
 
-Indicates if a hold is currently in place on this zone. Examples of such are 'away', 
+Indicates if a hold is currently in place on this zone. Examples of such are 'away',
 'home', 'sleep', or 'evening'
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | hold mode |
 
 ### Attribute `humidity`
 
-The target dehumidify set point (%) of the system. 
+The target dehumidify set point (%) of the system.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | dehumidify setpoint as an integer |
 
 ### Attribute `humidify_supported`
 
-Indicates if the system supports humidification. 
+Indicates if the system supports humidification.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Boolean | humidification supported |
 
 ### Attribute `dehumidify_supported`
 
-Indicates if the system supports dehumidification. 
+Indicates if the system supports dehumidification.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Boolean | dehumidification supported |
 
 
 ### Attribute `humidify_setpoint`
 
-The target humidify set point (%) of the system. 
+The target humidify set point (%) of the system.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | humidify setpoint as an integer |
 
 
 ### Attribute `dehumidify_setpoint`
 
-Same as `humidity` The target dehumidify set point (%) of the system. 
+Same as `humidity` The target dehumidify set point (%) of the system.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | dehumidify setpoint as an integer |
 
 
 ### Attribute `max_humidity`
 
-Hard-coded value indicating the maximum dehumidify set point (%) you can set, as an integer.  
+Hard-coded value indicating the maximum dehumidify set point (%) you can set, as an integer.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | maximum humidity set point, always 65 |
 
@@ -156,15 +156,15 @@ Hard-coded value indicating the maximum dehumidify set point (%) you can set, as
 
 The maximum temperature set point of the zone. This can change based on the thermostat's settings.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | maximum temperature, such as 90 |
 
 ### Attribute `min_humidity`
 
-Hard-coded value indicating the minimum dehumidify set point (%) you can set, as an integer.  
+Hard-coded value indicating the minimum dehumidify set point (%) you can set, as an integer.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | minimum humidity set point, always 35  |
 
@@ -172,7 +172,7 @@ Hard-coded value indicating the minimum dehumidify set point (%) you can set, as
 
 The minimum temperature set point of the zone. This can change based on the thermostat's settings.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | minimum temperature, such as 55 |
 
@@ -180,7 +180,7 @@ The minimum temperature set point of the zone. This can change based on the ther
 
 The thermostat model, such as 'TZON1050AC52ZAA'
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | thermostat model |
 
@@ -188,7 +188,7 @@ The thermostat model, such as 'TZON1050AC52ZAA'
 
 List of available operation modes such as 'AUTO,COOL,HEAT,OFF'
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | operation modes |
 
@@ -196,24 +196,24 @@ List of available operation modes such as 'AUTO,COOL,HEAT,OFF'
 
 The current operation mode, such as 'AUTO', 'COOL', 'HEAT', or 'OFF'
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | operation mode |
 
 ### Attribute `setpoint_status`
 
-This provides you with a system set point status, such as 'Holding Permanently', 
-'Following Schedule - Away', or 'Following Schedule - Home'. This is not an exhaustive list. 
+This provides you with a system set point status, such as 'Holding Permanently',
+'Following Schedule - Away', or 'Following Schedule - Home'. This is not an exhaustive list.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | set point status |
 
 ### Attribute `target_temp_high`
 
-The target cooling (upper-bound) temperature for the current zone. 
+The target cooling (upper-bound) temperature for the current zone.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | upper-bound target temperature |
 
@@ -221,51 +221,51 @@ The target cooling (upper-bound) temperature for the current zone.
 
 The target heating (lower-bound) temperature for the current zone.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | lower-bound target temperature |
 
 ### Attribute `target_temp_step`
 
-The step at which the temperature can be increased or decreased. For Fahrenheit, 
+The step at which the temperature can be increased or decreased. For Fahrenheit,
 this is 1.0 degrees per step, and for Celsius, this is 0.5 degrees per step.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Float | step |
 
 ### Attribute `temperature`
 
-Based on the current system mode, this is the target temperature for the zone. 
+Based on the current system mode, this is the target temperature for the zone.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | target temperature |
- 
+
 ### Attribute `thermostat_id`
 
 This is the main thermostat's ID, here for reference. This will match up with the 'id'
 in the JSON data provided by Nexia.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | thermostat ID |
 
 ### Attribute `thermostat_name`
 
 The name of the system. This will be shared across all zones of your Trane / American Standard
-system. 
+system.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | thermostat name|
 
 ### Attribute `zone_id`
 
-The zone ID for this particular zone, here for reference. This will match up with the 'id' 
-in the JSON data provided by Nexia under the 'zones' list. 
+The zone ID for this particular zone, here for reference. This will match up with the 'id'
+in the JSON data provided by Nexia under the 'zones' list.
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | Integer | zone ID |
 
@@ -273,15 +273,32 @@ in the JSON data provided by Nexia under the 'zones' list.
 
 The status of the zone, such as 'Cooling', or 'Heating"
 
-| Attribute type | Description | 
+| Attribute type | Description |
 | -------------- | ----------- |
 | String | zone status |
- 
- 
+
+
+## NexiaHome Attributes
+
+The following attribute is provided by the Nexia Home:
+`log_response`
+
+### Attribute `log_response`
+
+An instance attribute of NexiaHome that controls logging http response text.
+This can be True or False.
+It is initialized to False and you can change it to
+True when you want to collect http response text in your logs.
+
+| Attribute type | Description              |
+|----------------|--------------------------|
+| Boolean        | response logging control |
+
+
 ## Services
 
 The following `climate` services are provided by the Nexia Thermostat:
-`set_aux_heat`, `set_away_mode`, `set_fan_mode`, `set_hold_mode`, `set_humidity`, 
+`set_aux_heat`, `set_away_mode`, `set_fan_mode`, `set_hold_mode`, `set_humidity`,
 `set_operation_mode`, `set_temperature`, `turn_on`, `turn_off`
 
 The service `set_swing_mode` offered by the [Climate component](/components/climate/)
@@ -289,6 +306,16 @@ is not implemented for this thermostat.
 
 The following `nexia` climate service is provided by the Nexia Thermostat:
 `set_aircleaner_mode`
+
+The following additional service is provided by the Nexia Thermostat:
+`refresh_thermostat_data`
+
+### Service `refresh_thermostat_data`
+
+Refresh data in this thermostat instance.
+Note: Many other services refresh this data before completing,
+so you may not need to call this service to get fresh data.
+No arguments are passed to this service.
 
 ### Service `set_aux_heat`
 
@@ -310,7 +337,7 @@ Turns the away mode on or off for the thermostat.
 
 ### Service `set_fan_mode`
 
-Sets the fan mode for the system. See the `fan_list` attribute for options. This is a system-wide setting. 
+Sets the fan mode for the system. See the `fan_list` attribute for options. This is a system-wide setting.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -336,7 +363,7 @@ Sets the dehumidify set point of the system. Range from 35-65. This is a system-
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
-| `humidity` | no | The dehumidify setpoint, like 50.  
+| `humidity` | no | The dehumidify setpoint, like 50.
 
 ### Service `set_temperature`
 
@@ -354,7 +381,7 @@ be provided.
 
 ### Service `set_operation_mode`
 
-Sets the current operation mode of the thermostat. See attribute `operation_list` for options. 
+Sets the current operation mode of the thermostat. See attribute `operation_list` for options.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -363,7 +390,7 @@ Sets the current operation mode of the thermostat. See attribute `operation_list
 
 ### Service `turn_on`
 
-Turns the zone on. 
+Turns the zone on.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -371,7 +398,7 @@ Turns the zone on.
 
 ### Service `turn_off`
 
-Turns the zone off. 
+Turns the zone off.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -379,8 +406,8 @@ Turns the zone off.
 
 ### Service `set_aircleaner_mode`
 
-Part of the `nexia.` services. Sets the air cleaner mode. Options include 'AUTO', 'QUICK', and 
-'ALLERGY'. This is a system-wide setting. 
+Part of the `nexia.` services. Sets the air cleaner mode. Options include 'AUTO', 'QUICK', and
+'ALLERGY'. This is a system-wide setting.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
@@ -389,12 +416,36 @@ Part of the `nexia.` services. Sets the air cleaner mode. Options include 'AUTO'
 
 ### Service `set_humidify_setpoint`
 
-Part of the `nexia.` services. Sets the humidify setpoint. This is a system-wide setting. 
+Part of the `nexia.` services. Sets the humidify setpoint. This is a system-wide setting.
 
 | Service data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. Else targets all.
-| `humidity` | no | Humidify setpoint level, from 35 to 65. 
+| `humidity` | no | Humidify setpoint level, from 35 to 65.
+
+## NexiaThermostatZone Services
+
+The following services are provided by the Nexia Thermostat Zone:
+`get_sensors`, `load_current_sensor_state`
+
+### Service `get_sensors`
+
+Get the sensor detail data objects from this zone instance.
+Provides a list of sensor detail data objects.
+No arguments are passed to this service.
+
+### Service `load_current_sensor_state`
+
+Load the current state of a zone's sensors into the physical thermostat.
+Note: This service does not update data in this zone instance -
+many of the thermostat services do so.
+This service returns a bool indicating if it completed successfully.
+
+| Service data attribute | Optional | Default | Description                                    |
+|------------------------|----------|---------|------------------------------------------------|
+| `polling_delay`        | yes      | 0.7     | seconds to wait before each polling attempt    |
+| `max_polls`            | yes      | 50      | maximum number of times to poll for completion |
+
 
 [code-coverage]: https://codecov.io/gh/bdraco/nexia
 [code-cover-shield]: https://codecov.io/gh/bdraco/nexia/branch/master/graph/badge.svg

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -62,17 +62,15 @@ class NexiaHome:
         Connects to and provides the ability to get and set parameters of your
         Nexia connected thermostat.
 
+        :param session: ClientSession to use
         :param house_id: int - Your house_id. You can get this from logging in
-        and looking at the url once you're looking at your climate device.
-        https://www.mynexia.com/houses/<house_id>/climate
+                and looking at the url once you're looking at your climate device.
+                https://www.mynexia.com/houses/<house_id>/climate
         :param username: str - Your login email address
         :param password: str - Your login password
-        :param auto_login: bool - Default is True, Login now (True), or login
-        manually later (False)
-        :param auto_update: bool - Default is True, Update now (True), or update
-        manually later (False)
-
-        JSON update. Default is 300s.
+        :param device_name: str - Name of the device running this code
+        :param brand: str - Brand of the desired system (from nexia.const)
+        :param state_file: str | PathLike - File to use when persisting data
         """
 
         self.username = username
@@ -147,7 +145,7 @@ class NexiaHome:
     async def post_url(self, request_url: str, payload: dict) -> aiohttp.ClientResponse:
         """
         Posts data to the session from the url and payload
-        :param url: str
+        :param request_url: str
         :param payload: dict
         :return: response
         """
@@ -186,7 +184,8 @@ class NexiaHome:
     ) -> aiohttp.ClientResponse:
         """
         Returns the full session.get from the URL (ROOT_URL + url)
-        :param url: str
+        :param request_url: str
+        :param headers: headers to include in the get request
         :return: response
         """
         if not headers:
@@ -448,7 +447,7 @@ class NexiaHome:
         return [thermostat.thermostat_id for thermostat in self.thermostats]
 
     def get_automation_by_id(self, automation_id) -> NexiaAutomation:
-        """Get a automation by its nexia id."""
+        """Get an automation by its nexia id."""
         for automation in self.automations:
             if automation.automation_id == automation_id:
                 return automation

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -94,6 +94,7 @@ class NexiaHome:
         self.session = session
         self.loop = asyncio.get_running_loop()
         self._root_url_splits = urllib.parse.urlsplit(self.root_url)
+        self.log_response = False
 
     @property
     def API_MOBILE_PHONE_URL(self) -> str:  # pylint: disable=invalid-name
@@ -154,15 +155,11 @@ class NexiaHome:
             headers["X-ApiKey"] = str(self.api_key)
         return headers
 
-    async def post_url(
-        self, request_url: str, payload: dict,
-        log_response=False,
-    ) -> aiohttp.ClientResponse:
+    async def post_url(self, request_url: str, payload: dict) -> aiohttp.ClientResponse:
         """
         Posts data to the session from the url and payload
         :param request_url: str
         :param payload: dict
-        :param log_response: bool indicating to include response text in logs
         :return: response
         """
         headers = self._api_key_headers()
@@ -181,7 +178,7 @@ class NexiaHome:
             max_redirects=MAX_REDIRECTS,
         )
 
-        if log_response:
+        if self.log_response:
             _LOGGER.debug("POST: Response from url %s: status: %s:\n%s",
                           request_url, response.status, (await response.text()).strip())
         else:
@@ -202,14 +199,12 @@ class NexiaHome:
         return response
 
     async def get_url(
-        self, request_url: str, headers: dict[str, str] | None = None,
-        log_response=False,
+        self, request_url: str, headers: dict[str, str] | None = None
     ) -> aiohttp.ClientResponse:
         """
         Returns the full session.get from the URL and headers
         :param request_url: str
         :param headers: headers to include in the get request
-        :param log_response: bool indicating to include response text in logs
         :return: response
         """
         if not headers:
@@ -225,7 +220,7 @@ class NexiaHome:
             headers=headers,
             max_redirects=MAX_REDIRECTS,
         )
-        if log_response:
+        if self.log_response:
             _LOGGER.debug("GET: Response from url %s: status: %s:\n%s",
                           request_url, response.status, (await response.text()).strip())
         else:

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -154,8 +154,9 @@ class NexiaHome:
             headers["X-ApiKey"] = str(self.api_key)
         return headers
 
-    async def post_url(self, request_url: str, payload: dict,
-        log_response = False,
+    async def post_url(
+        self, request_url: str, payload: dict,
+        log_response=False,
     ) -> aiohttp.ClientResponse:
         """
         Posts data to the session from the url and payload
@@ -182,10 +183,10 @@ class NexiaHome:
 
         if log_response:
             _LOGGER.debug("POST: Response from url %s: status: %s:\n%s",
-                request_url, response.status, (await response.text()).strip())
+                          request_url, response.status, (await response.text()).strip())
         else:
             _LOGGER.debug("POST: Response from url %s: status: %s: %s",
-                request_url, response.status, response.content)
+                          request_url, response.status, response.content)
 
         if response.status == 302:
             # assuming its redirecting to login
@@ -202,7 +203,7 @@ class NexiaHome:
 
     async def get_url(
         self, request_url: str, headers: dict[str, str] | None = None,
-        log_response = False,
+        log_response=False,
     ) -> aiohttp.ClientResponse:
         """
         Returns the full session.get from the URL and headers
@@ -226,10 +227,10 @@ class NexiaHome:
         )
         if log_response:
             _LOGGER.debug("GET: Response from url %s: status: %s:\n%s",
-                request_url, response.status, (await response.text()).strip())
+                          request_url, response.status, (await response.text()).strip())
         else:
             _LOGGER.debug("GET: Response from url %s: status: %s: %s",
-                request_url, response.status, response.content)
+                          request_url, response.status, response.content)
 
         if response.status == 302:
             _LOGGER.debug(
@@ -336,13 +337,14 @@ class NexiaHome:
     def _update_devices(self):
         self.last_update = datetime.datetime.now()
         children = []
-        for child in self.devices_json:
-            type_ = child.get("type")
-            if not type_ or "thermostat" in type_:
-                children.append(child)
-            elif type_ == "group" and "_links" in child and "child" in child["_links"]:
-                for sub_child in child["_links"]["child"]:
-                    children.append(sub_child["data"])
+        if self.devices_json:
+            for child in self.devices_json:
+                type_ = child.get("type")
+                if not type_ or "thermostat" in type_:
+                    children.append(child)
+                elif type_ == "group" and "_links" in child and "child" in child["_links"]:
+                    for sub_child in child["_links"]["child"]:
+                        children.append(sub_child["data"])
 
         if self.thermostats is None:
             self.thermostats = []

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -485,6 +485,6 @@ def _extract_automations_from_houses_json(json_dict: dict) -> list[dict[str, Any
     )
 
 
-def _extract_items(json_dict: dict) -> list[dict[str, Any]]:
+def _extract_items(json_dict: Any) -> list[dict[str, Any]]:
     """Return the items key if it exists, otherwise the top level."""
     return json_dict.get("items", json_dict)

--- a/nexia/sensor.py
+++ b/nexia/sensor.py
@@ -1,6 +1,6 @@
 """Nexia Thermostat Sensor."""
 
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 
 class NexiaSensor(NamedTuple):
@@ -14,4 +14,8 @@ class NexiaSensor(NamedTuple):
     temperature_valid: bool
     humidity: int
     humidity_valid: bool
+    has_battery: bool
+    battery_level: Optional[int]
+    battery_valid: Optional[bool]
+
 # end class NexiaSensor

--- a/nexia/sensor.py
+++ b/nexia/sensor.py
@@ -1,0 +1,17 @@
+"""Nexia Thermostat Sensor."""
+
+from typing import NamedTuple
+
+
+class NexiaSensor(NamedTuple):
+    """Data object representing details of a nexia sensor"""
+    id: int
+    name: str
+    type: str
+    serial_number: str
+    weight: float
+    temperature: int
+    temperature_valid: bool
+    humidity: int
+    humidity_valid: bool
+# end class NexiaSensor

--- a/nexia/thermostat.py
+++ b/nexia/thermostat.py
@@ -1,4 +1,4 @@
-"""Nexia Themostat."""
+"""Nexia Thermostat."""
 from __future__ import annotations
 
 import logging
@@ -118,7 +118,7 @@ class NexiaThermostat:
 
     def has_relative_humidity(self):
         """
-        Capability indication of whether the thermostat has an relative
+        Capability indication of whether the thermostat has a relative
         humidity sensor
         :return: bool
         """
@@ -130,7 +130,7 @@ class NexiaThermostat:
         compressor
         :return: bool
         """
-        # This only shows up if its running on mobile
+        # This only shows up if it's running on mobile
         return True
 
     def has_emergency_heat(self):
@@ -157,14 +157,14 @@ class NexiaThermostat:
 
     def has_dehumidify_support(self):
         """
-        Indiciation of whether dehumidifying support is available.
+        Indication of whether dehumidifying support is available.
         :return: bool
         """
         return bool(self.get_thermostat_settings_key_or_none("dehumidify"))
 
     def has_humidify_support(self):
         """
-        Indiciation of whether humidifying support is available.
+        Indication of whether humidifying support is available.
         :return: bool
         """
         return bool(self.get_thermostat_settings_key_or_none("humidify"))
@@ -217,7 +217,7 @@ class NexiaThermostat:
 
         This is a hard-set limit in this code that I believe is universal to
         all TraneXl thermostats.
-        but kept for consistency)
+        (but kept for consistency)
         :return: (float, float)
         """
         return HUMIDITY_MIN, HUMIDITY_MAX
@@ -497,7 +497,7 @@ class NexiaThermostat:
         ):
             raise ValueError(
                 f"Setpoints must be between ({min_humidity} -"
-                f" {max_humidity}) and humdiify_setpoint must"
+                f" {max_humidity}) and humidify_setpoint must"
                 f" be <= dehumidify_setpoint"
             )
         if (dehumidify_supported) and not (
@@ -573,7 +573,7 @@ class NexiaThermostat:
         """
         Returns the thermostat value from deep inside the thermostat's
         JSON.
-        :param area: The area of the json to look i.e. "settings", "features", etc
+        :param area: The area of the json to look i.e. "settings", "features", etc.
         :param area_primary_key: The name of the primary key such as "name" or "key"
         :param key: str
         :return: value

--- a/nexia/thermostat.py
+++ b/nexia/thermostat.py
@@ -38,7 +38,7 @@ class NexiaThermostat:
         )
 
     @property
-    def API_MOBILE_THERMOSTAT_SELF_REF_URL(self):
+    def API_MOBILE_THERMOSTAT_SELF_REF_URL(self):  # pylint: disable=invalid-name
         return self._nexia_home.mobile_url + "/xxl_thermostats/{}"
 
     @property

--- a/nexia/thermostat.py
+++ b/nexia/thermostat.py
@@ -1,8 +1,10 @@
 """Nexia Thermostat."""
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from .const import AIR_CLEANER_MODES, BLOWER_OFF_STATUSES, HUMIDITY_MAX, HUMIDITY_MIN
 from .util import find_dict_with_keyvalue_in_json, find_humidity_setpoint, is_number
@@ -13,6 +15,20 @@ _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .home import NexiaHome
+
+
+class NexiaSensor(NamedTuple):
+    """Data object representing a nexia sensor details"""
+    id: int
+    name: str
+    type: str
+    serial_number: str
+    weight: float
+    temperature: int
+    temperature_valid: bool
+    humidity: int
+    humidity_valid: bool
+# end class NexiaSensor
 
 
 class NexiaThermostat:
@@ -104,6 +120,24 @@ class NexiaThermostat:
         :return: str
         """
         return self._get_thermostat_key("name")
+
+    def get_sensors(self) -> list[NexiaSensor]:
+        """Get the sensor detail data objects from this instance
+        :return: list of sensor detail data objects
+        """
+        sensors_json = self._get_thermostat_features_key("room_iq_sensors")["sensors"]
+        sensors: list[NexiaSensor] = []
+
+        for sensor_json in sensors_json:
+            sensors.append(NexiaSensor(*[sensor_json[fld] for fld in NexiaSensor._fields]))
+
+        return sensors
+
+    def _get_sensor_actions(self) -> dict[str, dict[str, Any]]:
+        """Get the actions offered by our sensors
+        :return: dictionary of sensor actions
+        """
+        return self._get_thermostat_features_key("room_iq_sensors")["actions"]
 
     ########################################################################
     # Supported Features
@@ -543,6 +577,51 @@ class NexiaThermostat:
         :return: None
         """
         await self.set_humidity_setpoints(humidify_setpoint=humidify_setpoint)
+
+    async def load_current_sensor_state(self) -> bool:
+        """Load the current state of its sensors into the physical thermostat.
+        :return: bool indicating completed
+        """
+        actions = self._get_sensor_actions()
+        request_cur_state = self._nexia_home.resolve_url(
+            actions["request_current_state"]["href"])
+
+        async with await self._nexia_home.post_url(request_cur_state, {}) as response:
+            # The polling path in the response has the form:
+            #   https://www.mynexia.com/backstage/announcements/<48-hex-digits>
+            polling_url = self._nexia_home.resolve_url(
+                (await response.json())["result"]["polling_path"])
+        retries = 50
+
+        while retries:
+            await asyncio.sleep(0.7)
+            async with await self._nexia_home.get_url(polling_url) as response:
+                payload = (await response.read()).strip()
+
+            if payload != b"null":
+                status = json.loads(payload)["status"]
+
+                if status != "success":
+                    _LOGGER.error("Unexpected status [%s] loading current sensor state",
+                                  status)
+
+                return True
+            retries -= 1
+        # end while waiting for status
+
+        _LOGGER.error("Gave up waiting for current sensor state")
+        return False
+
+    async def refresh_thermostat_data(self) -> None:
+        """Refresh data in this thermostat instance.
+        Note: Many other methods refresh this data before completing.
+        :return: None
+        """
+        self_ref = self._nexia_home.resolve_url(
+            self._get_thermostat_key("_links")["self"]["href"])
+
+        async with await self._nexia_home.get_url(self_ref) as response:
+            self.update_thermostat_json((await response.json())["result"])
 
     ########################################################################
     # Zone Get Methods

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -1,6 +1,8 @@
-"""Nexia Themostat Zone."""
+"""Nexia Thermostat Zone."""
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import math
 from typing import TYPE_CHECKING, Any
@@ -17,6 +19,7 @@ from .const import (
     UNIT_CELSIUS,
     ZONE_IDLE,
 )
+from .sensor import NexiaSensor
 from .util import find_dict_with_keyvalue_in_json
 
 _LOGGER = logging.getLogger(__name__)
@@ -251,6 +254,23 @@ class NexiaThermostatZone:
             return True
         return run_mode["current_value"] == HOLD_PERMANENT
 
+    def get_sensors(self) -> list[NexiaSensor]:
+        """Get the sensor detail data objects from this instance
+        :return: list of sensor detail data objects
+        """
+        sensors: list[NexiaSensor] = []
+        try:
+            sensors_json = self._get_zone_features("room_iq_sensors")["sensors"]
+
+            for sensor_json in sensors_json:
+                sensors.append(NexiaSensor(*[sensor_json[fld] for fld in NexiaSensor._fields]))
+
+        except KeyError:
+            # our json has no sensors
+            pass
+
+        return sensors
+
     ########################################################################
     # Zone Set Methods
 
@@ -428,9 +448,43 @@ class NexiaThermostatZone:
                 f"{OPERATION_MODES}"
             )
 
+    async def load_current_sensor_state(self, polling_delay = 0.7, max_polls = 50) -> bool:
+        """Load the current state of its sensors into the physical thermostat.
+        :param polling_delay: seconds to wait before each polling attempt
+        :param max_polls: maximum number of times to poll for completion
+        :return: bool indicating completed
+        """
+        req_cur_state = self.API_MOBILE_ZONE_URL.format(
+            end_point="request_current_sensor_state", zone_id=self.zone_id)
+
+        async with await self._nexia_home.post_url(req_cur_state, {}) as response:
+            # The polling path in the response has the form:
+            #   https://www.mynexia.com/backstage/announcements/<48-hex-digits>
+            polling_url = self._nexia_home.resolve_url(
+                (await response.json())["result"]["polling_path"])
+        retries = max_polls
+
+        while retries:
+            await asyncio.sleep(polling_delay)
+            async with await self._nexia_home.get_url(polling_url) as response:
+                payload = (await response.read()).strip()
+
+            if payload != b"null":
+                status = json.loads(payload)["status"]
+
+                if status != "success":
+                    _LOGGER.error("Unexpected status [%s] loading current sensor state",
+                                  status)
+                return True
+            retries -= 1
+        # end while waiting for status
+
+        _LOGGER.error("Gave up waiting for current sensor state")
+        return False
+
     def round_temp(self, temperature: float) -> float:
         """
-        Rounds the temperature to the nearest 1/2 degree for C and neareast 1
+        Rounds the temperature to the nearest 1/2 degree for C and nearest 1
         degree for F
         :param temperature: temperature to round
         :return: float rounded temperature
@@ -471,7 +525,7 @@ class NexiaThermostatZone:
 
     def _get_zone_setting_or_none(self, key: str) -> Any:
         """
-        Returns the zone value from the provided key in the zones's
+        Returns the zone value from the provided key in the zone's
         JSON.
         :param key: str
         :return: value

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -450,7 +450,7 @@ class NexiaThermostatZone:
             )
 
     async def load_current_sensor_state(self, polling_delay=0.7, max_polls=50) -> bool:
-        """Load the current state of its sensors into the physical thermostat.
+        """Load the current state of a zone's sensors into the physical thermostat.
         :param polling_delay: seconds to wait before each polling attempt
         :param max_polls: maximum number of times to poll for completion
         :return: bool indicating completed

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -448,7 +448,7 @@ class NexiaThermostatZone:
                 f"{OPERATION_MODES}"
             )
 
-    async def load_current_sensor_state(self, polling_delay = 0.7, max_polls = 50) -> bool:
+    async def load_current_sensor_state(self, polling_delay=0.7, max_polls=50) -> bool:
         """Load the current state of its sensors into the physical thermostat.
         :param polling_delay: seconds to wait before each polling attempt
         :param max_polls: maximum number of times to poll for completion

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -263,7 +263,8 @@ class NexiaThermostatZone:
             sensors_json = self._get_zone_features("room_iq_sensors")["sensors"]
 
             for sensor_json in sensors_json:
-                sensors.append(NexiaSensor(*[sensor_json[fld] for fld in NexiaSensor._fields]))
+                sensors.append(NexiaSensor(*[sensor_json.get(fld)
+                                             for fld in NexiaSensor._fields]))
 
         except KeyError:
             # our json has no sensors

--- a/pylintrc
+++ b/pylintrc
@@ -33,4 +33,4 @@ disable=
   missing-docstring,
 
 [EXCEPTIONS]
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/tests/fixtures/sensors_xl1050_house.json
+++ b/tests/fixtures/sensors_xl1050_house.json
@@ -1,0 +1,1187 @@
+{
+   "success": true,
+   "error": null,
+   "result": {
+      "id": 2582941,
+      "name": "My Home",
+      "third_party_integrations": [],
+      "latitude": null,
+      "longitude": null,
+      "time_zone": "America/New_York",
+      "dealer_opt_in": true,
+      "room_iq_enabled": true,
+      "_links": {
+         "self": {
+            "href": "https://www.mynexia.com/mobile/houses/2582941"
+         },
+         "edit": [
+            {
+               "href": "https://www.mynexia.com/mobile/houses/2582941/edit",
+               "method": "GET"
+            }
+         ],
+         "child": [
+            {
+               "href": "https://www.mynexia.com/mobile/houses/2582941/devices",
+               "type": "application/vnd.nexia.collection+json",
+               "data": {
+                  "items": [
+                     {
+                        "id": 5378307,
+                        "name": "Center",
+                        "name_editable": true,
+                        "features": [
+                           {
+                              "name": "advanced_info",
+                              "items": [
+                                 {
+                                    "type": "label_value",
+                                    "label": "Model",
+                                    "value": "XL1050"
+                                 },
+                                 {
+                                    "type": "label_value",
+                                    "label": "AUID",
+                                    "value": "0295CB84"
+                                 },
+                                 {
+                                    "type": "label_value",
+                                    "label": "Firmware Build Number",
+                                    "value": "1726826973"
+                                 },
+                                 {
+                                    "type": "label_value",
+                                    "label": "Firmware Build Date",
+                                    "value": "2024-09-20 10:09:33 UTC"
+                                 },
+                                 {
+                                    "type": "label_value",
+                                    "label": "Firmware Version",
+                                    "value": "5.11.1"
+                                 }
+                              ]
+                           },
+                           {
+                              "name": "thermostat",
+                              "scale": "f",
+                              "temperature": 69,
+                              "device_identifier": "XxlZone-85034552",
+                              "status": "System Idle",
+                              "status_icon": null,
+                              "actions": {
+                                 "set_heat_setpoint": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/setpoints"
+                                 }
+                              },
+                              "setpoint_delta": 3,
+                              "setpoint_increment": 1.0,
+                              "setpoint_heat_min": 55,
+                              "setpoint_heat_max": 90,
+                              "setpoint_cool_min": 60,
+                              "setpoint_cool_max": 99,
+                              "setpoint_heat": 69,
+                              "system_status": "System Idle",
+                              "operating_state": "idle"
+                           },
+                           {
+                              "name": "connection",
+                              "signal_strength": "unknown",
+                              "is_connected": true
+                           },
+                           {
+                              "name": "dealer_contact_info",
+                              "has_dealer_identifier": true,
+                              "actions": {
+                                 "request_current_dealer_info": {
+                                    "method": "GET",
+                                    "href": "https://www.mynexia.com/mobile/dealers/7043919191"
+                                 },
+                                 "request_dealers_by_zip": {
+                                    "method": "POST",
+                                    "href": "https://www.mynexia.com/mobile/dealers/5378307/search"
+                                 }
+                              }
+                           },
+                           {
+                              "name": "thermostat_mode",
+                              "label": "System Mode",
+                              "value": "HEAT",
+                              "display_value": "Heating",
+                              "options": [
+                                 {
+                                    "id": "thermostat_mode",
+                                    "label": "System Mode",
+                                    "value": "thermostat_mode",
+                                    "header": true
+                                 },
+                                 {
+                                    "value": "AUTO",
+                                    "label": "Auto"
+                                 },
+                                 {
+                                    "value": "COOL",
+                                    "label": "Cooling"
+                                 },
+                                 {
+                                    "value": "HEAT",
+                                    "label": "Heating"
+                                 },
+                                 {
+                                    "value": "OFF",
+                                    "label": "Off"
+                                 }
+                              ],
+                              "actions": {
+                                 "update_thermostat_mode": {
+                                    "method": "POST",
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/zone_mode"
+                                 }
+                              }
+                           },
+                           {
+                              "name": "thermostat_run_mode",
+                              "label": "Run Mode",
+                              "options": [
+                                 {
+                                    "id": "thermostat_run_mode",
+                                    "label": "Run Mode",
+                                    "value": "thermostat_run_mode",
+                                    "header": true
+                                 },
+                                 {
+                                    "id": "info_text",
+                                    "label": "Follow or override the schedule.",
+                                    "value": "info_text",
+                                    "info": true
+                                 },
+                                 {
+                                    "value": "permanent_hold",
+                                    "label": "Permanent Hold"
+                                 },
+                                 {
+                                    "value": "run_schedule",
+                                    "label": "Run Schedule"
+                                 }
+                              ],
+                              "value": "run_schedule",
+                              "display_value": "Run Schedule",
+                              "actions": {
+                                 "update_thermostat_run_mode": {
+                                    "method": "POST",
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/run_mode"
+                                 }
+                              }
+                           },
+                           {
+                              "name": "room_iq_sensors",
+                              "sensors": [
+                                 {
+                                    "id": 17687546,
+                                    "name": "Center",
+                                    "icon": {
+                                       "name": "room_iq_onboard",
+                                       "modifiers": []
+                                    },
+                                    "type": "thermostat",
+                                    "serial_number": "NativeIDTUniqueID",
+                                    "weight": 0.5,
+                                    "temperature": 68,
+                                    "temperature_valid": true,
+                                    "humidity": 32,
+                                    "humidity_valid": true,
+                                    "has_online": false,
+                                    "has_battery": false
+                                 },
+                                 {
+                                    "id": 17687549,
+                                    "name": "Upstairs",
+                                    "icon": {
+                                       "name": "room_iq_wireless",
+                                       "modifiers": []
+                                    },
+                                    "type": "930",
+                                    "serial_number": "2410R5C53X",
+                                    "weight": 0.5,
+                                    "temperature": 69,
+                                    "temperature_valid": true,
+                                    "humidity": 32,
+                                    "humidity_valid": true,
+                                    "has_online": true,
+                                    "connected": true,
+                                    "has_battery": true,
+                                    "battery_level": 95,
+                                    "battery_low": false,
+                                    "battery_valid": true
+                                 }
+                              ],
+                              "should_show": true,
+                              "actions": {
+                                 "request_current_state": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state"
+                                 },
+                                 "update_active_sensors": {
+                                    "method": "POST",
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/update_active_sensors"
+                                 }
+                              }
+                           },
+                           {
+                              "name": "preset_setpoints",
+                              "presets": {
+                                 "1": {
+                                    "cool": 78,
+                                    "heat": 70
+                                 },
+                                 "2": {
+                                    "cool": 85,
+                                    "heat": 62
+                                 },
+                                 "3": {
+                                    "cool": 82,
+                                    "heat": 62
+                                 }
+                              }
+                           },
+                           {
+                              "name": "thermostat_fan_mode",
+                              "label": "Fan Mode",
+                              "options": [
+                                 {
+                                    "id": "thermostat_fan_mode",
+                                    "label": "Fan Mode",
+                                    "value": "thermostat_fan_mode",
+                                    "header": true
+                                 },
+                                 {
+                                    "value": "auto",
+                                    "label": "Auto"
+                                 },
+                                 {
+                                    "value": "on",
+                                    "label": "On"
+                                 },
+                                 {
+                                    "value": "circulate",
+                                    "label": "Circulate"
+                                 }
+                              ],
+                              "value": "circulate",
+                              "display_value": "Circulate",
+                              "status_icon": {
+                                 "name": "thermostat_fan_off",
+                                 "modifiers": []
+                              },
+                              "actions": {
+                                 "update_thermostat_fan_mode": {
+                                    "method": "POST",
+                                    "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/fan_mode"
+                                 }
+                              }
+                           },
+                           {
+                              "name": "thermostat_default_fan_mode",
+                              "value": "circulate",
+                              "actions": {
+                                 "update_thermostat_default_fan_mode": {
+                                    "method": "POST",
+                                    "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/fan_mode"
+                                 }
+                              }
+                           },
+                           {
+                              "name": "gen_2_app",
+                              "is_supported": false,
+                              "validation_failures": [
+                                 "Thermostat has wireless sensors.",
+                                 "Unauthorized to use Gen 2 App."
+                              ]
+                           },
+                           {
+                              "name": "schedule",
+                              "enabled": true,
+                              "max_period_name_length": 10,
+                              "setpoint_increment": 1.0,
+                              "collection_url": "https://www.mynexia.com/mobile/schedules?device_identifier=TraneXl1050-5378307\u0026house_id=2582941",
+                              "actions": {
+                                 "get_active_schedule": {
+                                    "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_active_schedule?device_identifier=TraneXl1050-5378307",
+                                    "method": "POST"
+                                 },
+                                 "set_active_schedule": {
+                                    "href": "https://www.mynexia.com/mobile/thermostat_schedules/set_active_schedule?device_identifier=TraneXl1050-5378307",
+                                    "method": "POST"
+                                 },
+                                 "get_default_schedule": {
+                                    "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_default_schedule?device_identifier=TraneXl1050-5378307",
+                                    "method": "GET"
+                                 },
+                                 "enable_scheduling": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/scheduling_enabled",
+                                    "method": "POST",
+                                    "data": {
+                                       "value": true
+                                    }
+                                 }
+                              },
+                              "can_add_remove_periods": true,
+                              "max_periods_per_day": 4
+                           },
+                           {
+                              "name": "runtime_history",
+                              "actions": {
+                                 "get_runtime_history": {
+                                    "method": "GET",
+                                    "href": "https://www.mynexia.com/mobile/runtime_history/TraneXl1050-5378307?report_type=daily"
+                                 },
+                                 "get_monthly_runtime_history": {
+                                    "method": "GET",
+                                    "href": "https://www.mynexia.com/mobile/runtime_history/TraneXl1050-5378307?report_type=monthly"
+                                 }
+                              }
+                           }
+                        ],
+                        "icon": [
+                           {
+                              "name": "thermostat",
+                              "modifiers": [
+                                 "temperature-69"
+                              ]
+                           }
+                        ],
+                        "_links": {
+                           "self": {
+                              "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307"
+                           },
+                           "nexia:history": {
+                              "href": "https://www.mynexia.com/mobile/houses/2582941/events?device_id=5378307"
+                           },
+                           "filter_events": {
+                              "href": "https://www.mynexia.com/mobile/houses/2582941/events/collection?sys_guid=e16684f6-b1e3-4e25-b006-e4d599dab2e9"
+                           }
+                        },
+                        "last_updated_at": "2025-01-06T17:45:09.000-05:00",
+                        "settings": [
+                           {
+                              "type": "preset_selected",
+                              "title": "Preset",
+                              "current_value": 0,
+                              "options": [
+                                 {
+                                    "value": 0,
+                                    "label": "None"
+                                 },
+                                 {
+                                    "value": 1,
+                                    "label": "Home"
+                                 },
+                                 {
+                                    "value": 2,
+                                    "label": "Away"
+                                 },
+                                 {
+                                    "value": 3,
+                                    "label": "Sleep"
+                                 }
+                              ],
+                              "labels": [
+                                 "None",
+                                 "Home",
+                                 "Away",
+                                 "Sleep"
+                              ],
+                              "values": [
+                                 0,
+                                 1,
+                                 2,
+                                 3
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/preset_selected"
+                                 }
+                              }
+                           },
+                           {
+                              "type": "system_mode",
+                              "title": "System Mode",
+                              "current_value": "HEAT",
+                              "options": [
+                                 {
+                                    "value": "AUTO",
+                                    "label": "Auto"
+                                 },
+                                 {
+                                    "value": "COOL",
+                                    "label": "Cooling"
+                                 },
+                                 {
+                                    "value": "HEAT",
+                                    "label": "Heating"
+                                 },
+                                 {
+                                    "value": "OFF",
+                                    "label": "Off"
+                                 }
+                              ],
+                              "labels": [
+                                 "Auto",
+                                 "Cooling",
+                                 "Heating",
+                                 "Off"
+                              ],
+                              "values": [
+                                 "AUTO",
+                                 "COOL",
+                                 "HEAT",
+                                 "OFF"
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/zone_mode"
+                                 }
+                              }
+                           },
+                           {
+                              "type": "run_mode",
+                              "title": "Run Mode",
+                              "current_value": "run_schedule",
+                              "options": [
+                                 {
+                                    "value": "permanent_hold",
+                                    "label": "Permanent Hold"
+                                 },
+                                 {
+                                    "value": "run_schedule",
+                                    "label": "Run Schedule"
+                                 }
+                              ],
+                              "labels": [
+                                 "Permanent Hold",
+                                 "Run Schedule"
+                              ],
+                              "values": [
+                                 "permanent_hold",
+                                 "run_schedule"
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/run_mode"
+                                 }
+                              }
+                           },
+                           {
+                              "type": "scheduling_enabled",
+                              "title": "Scheduling",
+                              "current_value": true,
+                              "options": [
+                                 {
+                                    "value": true,
+                                    "label": "ON"
+                                 },
+                                 {
+                                    "value": false,
+                                    "label": "OFF"
+                                 }
+                              ],
+                              "labels": [
+                                 "ON",
+                                 "OFF"
+                              ],
+                              "values": [
+                                 true,
+                                 false
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/scheduling_enabled"
+                                 }
+                              }
+                           },
+                           {
+                              "type": "fan_mode",
+                              "title": "Fan Mode",
+                              "current_value": "circulate",
+                              "options": [
+                                 {
+                                    "value": "auto",
+                                    "label": "Auto"
+                                 },
+                                 {
+                                    "value": "on",
+                                    "label": "On"
+                                 },
+                                 {
+                                    "value": "circulate",
+                                    "label": "Circulate"
+                                 }
+                              ],
+                              "labels": [
+                                 "Auto",
+                                 "On",
+                                 "Circulate"
+                              ],
+                              "values": [
+                                 "auto",
+                                 "on",
+                                 "circulate"
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/fan_mode"
+                                 }
+                              }
+                           },
+                           {
+                              "type": "fan_circulation_time",
+                              "title": "Fan Circulation Time",
+                              "current_value": 10,
+                              "options": [
+                                 {
+                                    "value": 10,
+                                    "label": "10 minutes"
+                                 },
+                                 {
+                                    "value": 15,
+                                    "label": "15 minutes"
+                                 },
+                                 {
+                                    "value": 20,
+                                    "label": "20 minutes"
+                                 },
+                                 {
+                                    "value": 25,
+                                    "label": "25 minutes"
+                                 },
+                                 {
+                                    "value": 30,
+                                    "label": "30 minutes"
+                                 },
+                                 {
+                                    "value": 35,
+                                    "label": "35 minutes"
+                                 },
+                                 {
+                                    "value": 40,
+                                    "label": "40 minutes"
+                                 },
+                                 {
+                                    "value": 45,
+                                    "label": "45 minutes"
+                                 },
+                                 {
+                                    "value": 50,
+                                    "label": "50 minutes"
+                                 },
+                                 {
+                                    "value": 55,
+                                    "label": "55 minutes"
+                                 }
+                              ],
+                              "labels": [
+                                 "10 minutes",
+                                 "15 minutes",
+                                 "20 minutes",
+                                 "25 minutes",
+                                 "30 minutes",
+                                 "35 minutes",
+                                 "40 minutes",
+                                 "45 minutes",
+                                 "50 minutes",
+                                 "55 minutes"
+                              ],
+                              "values": [
+                                 10,
+                                 15,
+                                 20,
+                                 25,
+                                 30,
+                                 35,
+                                 40,
+                                 45,
+                                 50,
+                                 55
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/fan_circulation_time"
+                                 }
+                              }
+                           },
+                           {
+                              "type": "air_cleaner_mode",
+                              "title": "Air Cleaner Mode",
+                              "current_value": "auto",
+                              "options": [
+                                 {
+                                    "value": "auto",
+                                    "label": "Auto"
+                                 },
+                                 {
+                                    "value": "quick",
+                                    "label": "Quick"
+                                 },
+                                 {
+                                    "value": "allergy",
+                                    "label": "Allergy"
+                                 }
+                              ],
+                              "labels": [
+                                 "Auto",
+                                 "Quick",
+                                 "Allergy"
+                              ],
+                              "values": [
+                                 "auto",
+                                 "quick",
+                                 "allergy"
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/air_cleaner_mode"
+                                 }
+                              }
+                           },
+                           {
+                              "type": "dehumidify",
+                              "title": "Cooling Dehumidify Set Point",
+                              "current_value": 0.5,
+                              "options": [
+                                 {
+                                    "value": 0.35,
+                                    "label": "35%"
+                                 },
+                                 {
+                                    "value": 0.4,
+                                    "label": "40%"
+                                 },
+                                 {
+                                    "value": 0.45,
+                                    "label": "45%"
+                                 },
+                                 {
+                                    "value": 0.5,
+                                    "label": "50%"
+                                 },
+                                 {
+                                    "value": 0.55,
+                                    "label": "55%"
+                                 },
+                                 {
+                                    "value": 0.6,
+                                    "label": "60%"
+                                 },
+                                 {
+                                    "value": 0.65,
+                                    "label": "65%"
+                                 }
+                              ],
+                              "labels": [
+                                 "35%",
+                                 "40%",
+                                 "45%",
+                                 "50%",
+                                 "55%",
+                                 "60%",
+                                 "65%"
+                              ],
+                              "values": [
+                                 0.35,
+                                 0.4,
+                                 0.45,
+                                 0.5,
+                                 0.55,
+                                 0.6,
+                                 0.65
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/dehumidify"
+                                 }
+                              }
+                           },
+                           {
+                              "type": "emergency_heat",
+                              "title": "Emergency Heat",
+                              "current_value": false,
+                              "options": [
+                                 {
+                                    "value": true,
+                                    "label": "ON"
+                                 },
+                                 {
+                                    "value": false,
+                                    "label": "OFF"
+                                 }
+                              ],
+                              "labels": [
+                                 "ON",
+                                 "OFF"
+                              ],
+                              "values": [
+                                 true,
+                                 false
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/emergency_heat"
+                                 }
+                              }
+                           },
+                           {
+                              "type": "scale",
+                              "title": "Temperature Scale",
+                              "current_value": "f",
+                              "options": [
+                                 {
+                                    "value": "f",
+                                    "label": "F"
+                                 },
+                                 {
+                                    "value": "c",
+                                    "label": "C"
+                                 }
+                              ],
+                              "labels": [
+                                 "F",
+                                 "C"
+                              ],
+                              "values": [
+                                 "f",
+                                 "c"
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/scale"
+                                 }
+                              }
+                           }
+                        ],
+                        "status_secondary": null,
+                        "status_tertiary": null,
+                        "type": "xxl_thermostat",
+                        "has_outdoor_temperature": true,
+                        "outdoor_temperature": "39",
+                        "has_indoor_humidity": true,
+                        "connected": true,
+                        "indoor_humidity": "33",
+                        "system_status": "System Idle",
+                        "delta": 3,
+                        "manufacturer": "AmericanStandard",
+                        "country_code": "US",
+                        "state_code": "NC",
+                        "zones": [
+                           {
+                              "type": "xxl_zone",
+                              "id": 85034552,
+                              "name": "NativeZone",
+                              "current_zone_mode": "HEAT",
+                              "temperature": 69,
+                              "setpoints": {
+                                 "heat": 69,
+                                 "cool": null
+                              },
+                              "operating_state": "",
+                              "heating_setpoint": 69,
+                              "cooling_setpoint": null,
+                              "zone_status": "",
+                              "settings": [],
+                              "icon": {
+                                 "name": "thermostat",
+                                 "modifiers": [
+                                    "temperature-69"
+                                 ]
+                              },
+                              "features": [
+                                 {
+                                    "name": "thermostat",
+                                    "scale": "f",
+                                    "temperature": 69,
+                                    "device_identifier": "XxlZone-85034552",
+                                    "status": "",
+                                    "status_icon": null,
+                                    "actions": {
+                                       "set_heat_setpoint": {
+                                          "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/setpoints"
+                                       }
+                                    },
+                                    "setpoint_delta": 3,
+                                    "setpoint_increment": 1.0,
+                                    "setpoint_heat_min": 55,
+                                    "setpoint_heat_max": 90,
+                                    "setpoint_cool_min": 60,
+                                    "setpoint_cool_max": 99,
+                                    "setpoint_heat": 69,
+                                    "system_status": "System Idle"
+                                 },
+                                 {
+                                    "name": "connection",
+                                    "signal_strength": "unknown",
+                                    "is_connected": true
+                                 },
+                                 {
+                                    "name": "dealer_contact_info",
+                                    "has_dealer_identifier": true,
+                                    "actions": {
+                                       "request_current_dealer_info": {
+                                          "method": "GET",
+                                          "href": "https://www.mynexia.com/mobile/dealers/7043919191"
+                                       },
+                                       "request_dealers_by_zip": {
+                                          "method": "POST",
+                                          "href": "https://www.mynexia.com/mobile/dealers/5378307/search"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    "name": "thermostat_mode",
+                                    "label": "System Mode",
+                                    "value": "HEAT",
+                                    "display_value": "Heating",
+                                    "options": [
+                                       {
+                                          "id": "thermostat_mode",
+                                          "label": "System Mode",
+                                          "value": "thermostat_mode",
+                                          "header": true
+                                       },
+                                       {
+                                          "value": "AUTO",
+                                          "label": "Auto"
+                                       },
+                                       {
+                                          "value": "COOL",
+                                          "label": "Cooling"
+                                       },
+                                       {
+                                          "value": "HEAT",
+                                          "label": "Heating"
+                                       },
+                                       {
+                                          "value": "OFF",
+                                          "label": "Off"
+                                       }
+                                    ],
+                                    "actions": {
+                                       "update_thermostat_mode": {
+                                          "method": "POST",
+                                          "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/zone_mode"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    "name": "thermostat_run_mode",
+                                    "label": "Run Mode",
+                                    "options": [
+                                       {
+                                          "id": "thermostat_run_mode",
+                                          "label": "Run Mode",
+                                          "value": "thermostat_run_mode",
+                                          "header": true
+                                       },
+                                       {
+                                          "id": "info_text",
+                                          "label": "Follow or override the schedule.",
+                                          "value": "info_text",
+                                          "info": true
+                                       },
+                                       {
+                                          "value": "permanent_hold",
+                                          "label": "Permanent Hold"
+                                       },
+                                       {
+                                          "value": "run_schedule",
+                                          "label": "Run Schedule"
+                                       }
+                                    ],
+                                    "value": "run_schedule",
+                                    "display_value": "Run Schedule",
+                                    "actions": {
+                                       "update_thermostat_run_mode": {
+                                          "method": "POST",
+                                          "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/run_mode"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    "name": "room_iq_sensors",
+                                    "sensors": [
+                                       {
+                                          "id": 17687546,
+                                          "name": "Center",
+                                          "icon": {
+                                             "name": "room_iq_onboard",
+                                             "modifiers": []
+                                          },
+                                          "type": "thermostat",
+                                          "serial_number": "NativeIDTUniqueID",
+                                          "weight": 0.5,
+                                          "temperature": 68,
+                                          "temperature_valid": true,
+                                          "humidity": 32,
+                                          "humidity_valid": true,
+                                          "has_online": false,
+                                          "has_battery": false
+                                       },
+                                       {
+                                          "id": 17687549,
+                                          "name": "Upstairs",
+                                          "icon": {
+                                             "name": "room_iq_wireless",
+                                             "modifiers": []
+                                          },
+                                          "type": "930",
+                                          "serial_number": "2410R5C53X",
+                                          "weight": 0.5,
+                                          "temperature": 69,
+                                          "temperature_valid": true,
+                                          "humidity": 32,
+                                          "humidity_valid": true,
+                                          "has_online": true,
+                                          "connected": true,
+                                          "has_battery": true,
+                                          "battery_level": 95,
+                                          "battery_low": false,
+                                          "battery_valid": true
+                                       }
+                                    ],
+                                    "should_show": true,
+                                    "actions": {
+                                       "request_current_state": {
+                                          "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state"
+                                       },
+                                       "update_active_sensors": {
+                                          "method": "POST",
+                                          "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/update_active_sensors"
+                                       }
+                                    }
+                                 },
+                                 {
+                                    "name": "preset_setpoints",
+                                    "presets": {
+                                       "1": {
+                                          "cool": 78,
+                                          "heat": 70
+                                       },
+                                       "2": {
+                                          "cool": 85,
+                                          "heat": 62
+                                       },
+                                       "3": {
+                                          "cool": 82,
+                                          "heat": 62
+                                       }
+                                    }
+                                 },
+                                 {
+                                    "name": "schedule",
+                                    "enabled": true,
+                                    "max_period_name_length": 10,
+                                    "setpoint_increment": 1.0,
+                                    "collection_url": "https://www.mynexia.com/mobile/schedules?device_identifier=XxlZone-85034552\u0026house_id=2582941",
+                                    "actions": {
+                                       "get_active_schedule": {
+                                          "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_active_schedule?device_identifier=XxlZone-85034552",
+                                          "method": "POST"
+                                       },
+                                       "set_active_schedule": {
+                                          "href": "https://www.mynexia.com/mobile/thermostat_schedules/set_active_schedule?device_identifier=XxlZone-85034552",
+                                          "method": "POST"
+                                       },
+                                       "get_default_schedule": {
+                                          "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_default_schedule?device_identifier=XxlZone-85034552",
+                                          "method": "GET"
+                                       },
+                                       "enable_scheduling": {
+                                          "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/scheduling_enabled",
+                                          "method": "POST",
+                                          "data": {
+                                             "value": true
+                                          }
+                                       }
+                                    },
+                                    "can_add_remove_periods": true,
+                                    "max_periods_per_day": 4
+                                 }
+                              ],
+                              "_links": {
+                                 "self": {
+                                    "href": "https://www.mynexia.com/mobile/xxl_zones/85034552"
+                                 }
+                              }
+                           }
+                        ],
+                        "generic_input_sensors": []
+                     }
+                  ],
+                  "_links": {
+                     "self": {
+                        "href": "https://www.mynexia.com/mobile/houses/2582941/devices"
+                     },
+                     "template": {
+                        "data": {
+                           "title": null,
+                           "fields": [],
+                           "_links": {
+                              "child-schema": [
+                                 {
+                                    "data": {
+                                       "label": "Connect New Device",
+                                       "icon": {
+                                          "name": "new_device",
+                                          "modifiers": []
+                                       },
+                                       "_links": {
+                                          "next": {
+                                             "href": "https://www.mynexia.com/mobile/houses/2582941/enrollables_schema"
+                                          }
+                                       }
+                                    }
+                                 },
+                                 {
+                                    "data": {
+                                       "label": "Create Group",
+                                       "icon": {
+                                          "name": "create_group",
+                                          "modifiers": []
+                                       },
+                                       "_links": {
+                                          "next": {
+                                             "href": "https://www.mynexia.com/mobile/houses/2582941/groups/new"
+                                          }
+                                       }
+                                    }
+                                 }
+                              ]
+                           }
+                        }
+                     }
+                  },
+                  "item_type": "application/vnd.nexia.device+json"
+               }
+            },
+            {
+               "href": "https://www.mynexia.com/mobile/houses/2582941/automations",
+               "type": "application/vnd.nexia.collection+json",
+               "data": {
+                  "items": [
+                     {
+                        "id": 4995413,
+                        "name": "My First Automation",
+                        "enabled": false,
+                        "settings": [],
+                        "triggers": [],
+                        "description": "Click the Edit button to set up automation for your devices.",
+                        "icon": [],
+                        "_links": {
+                           "self": {
+                              "href": "https://www.mynexia.com/mobile/automations/4995413"
+                           },
+                           "edit": {
+                              "href": "https://www.mynexia.com/mobile/automation_edit_buffers?automation_id=4995413",
+                              "method": "POST"
+                           },
+                           "nexia:history": {
+                              "href": "https://www.mynexia.com/mobile/houses/2582941/events?automation_id=4995413"
+                           },
+                           "filter_events": {
+                              "href": "https://www.mynexia.com/mobile/houses/2582941/events/collection?sys_guid=d827e212-3055-4835-8bda-333d26f05c9d"
+                           }
+                        }
+                     }
+                  ],
+                  "_links": {
+                     "self": {
+                        "href": "https://www.mynexia.com/mobile/houses/2582941/automations"
+                     },
+                     "template": {
+                        "href": "https://www.mynexia.com/mobile/houses/2582941/automation_edit_buffers",
+                        "method": "POST"
+                     }
+                  },
+                  "item_type": "application/vnd.nexia.automation+json"
+               }
+            },
+            {
+               "href": "https://www.mynexia.com/mobile/houses/2582941/modes",
+               "type": "application/vnd.nexia.collection+json",
+               "data": {
+                  "items": [
+                     {
+                        "id": 6631129,
+                        "name": "Day",
+                        "current_mode": false,
+                        "icon": "home.png",
+                        "settings": [],
+                        "_links": {
+                           "self": {
+                              "href": "https://www.mynexia.com/mobile/modes/6631129"
+                           }
+                        }
+                     },
+                     {
+                        "id": 6631132,
+                        "name": "Night",
+                        "current_mode": true,
+                        "icon": "home.png",
+                        "settings": [],
+                        "_links": {
+                           "self": {
+                              "href": "https://www.mynexia.com/mobile/modes/6631132"
+                           }
+                        }
+                     }
+                  ],
+                  "_links": {
+                     "self": {
+                        "href": "https://www.mynexia.com/mobile/houses/2582941/modes"
+                     }
+                  },
+                  "item_type": "application/vnd.nexia.mode+json"
+               }
+            },
+            {
+               "href": "https://www.mynexia.com/mobile/houses/2582941/events/collection",
+               "type": "application/vnd.nexia.collection+json",
+               "data": {
+                  "item_type": "application/vnd.nexia.event+json"
+               }
+            },
+            {
+               "href": "https://www.mynexia.com/mobile/houses/2582941/videos/collection",
+               "type": "application/vnd.nexia.collection+json",
+               "data": {
+                  "item_type": "application/vnd.nexia.video+json"
+               }
+            },
+            {
+               "href": "https://www.mynexia.com/mobile/choices",
+               "type": "application/vnd.nexia.collection+json",
+               "data": {
+                  "items": [],
+                  "_links": {
+                     "self": {
+                        "href": "https://www.mynexia.com/mobile/choices"
+                     }
+                  },
+                  "item_type": "application/vnd.nexia.choice+json"
+               }
+            }
+         ],
+         "feature_code_url": [
+            {
+               "href": "https://www.mynexia.com/mobile/houses/2582941/feature_code",
+               "method": "POST"
+            }
+         ],
+         "remove_zwave_device": [
+            {
+               "href": "https://www.mynexia.com/mobile/houses/2582941/remove_zwave_device",
+               "cancel_href": "https://www.mynexia.com/mobile/houses/2582941/cancel_remove_zwave_device",
+               "method": "POST",
+               "timeout": 240,
+               "display": true
+            }
+         ]
+      }
+   }
+}

--- a/tests/fixtures/sensors_xl1050_thermostat.json
+++ b/tests/fixtures/sensors_xl1050_thermostat.json
@@ -1,0 +1,990 @@
+{
+   "success": true,
+   "error": null,
+   "result": {
+      "id": 5378307,
+      "name": "Center",
+      "name_editable": true,
+      "features": [
+         {
+            "name": "advanced_info",
+            "items": [
+               {
+                  "type": "label_value",
+                  "label": "Model",
+                  "value": "XL1050"
+               },
+               {
+                  "type": "label_value",
+                  "label": "AUID",
+                  "value": "0295CB84"
+               },
+               {
+                  "type": "label_value",
+                  "label": "Firmware Build Number",
+                  "value": "1726826973"
+               },
+               {
+                  "type": "label_value",
+                  "label": "Firmware Build Date",
+                  "value": "2024-09-20 10:09:33 UTC"
+               },
+               {
+                  "type": "label_value",
+                  "label": "Firmware Version",
+                  "value": "5.11.1"
+               }
+            ]
+         },
+         {
+            "name": "thermostat",
+            "scale": "f",
+            "temperature": 69,
+            "device_identifier": "XxlZone-85034552",
+            "status": "System Idle",
+            "status_icon": null,
+            "actions": {
+               "set_heat_setpoint": {
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/setpoints"
+               }
+            },
+            "setpoint_delta": 3,
+            "setpoint_increment": 1.0,
+            "setpoint_heat_min": 55,
+            "setpoint_heat_max": 90,
+            "setpoint_cool_min": 60,
+            "setpoint_cool_max": 99,
+            "setpoint_heat": 69,
+            "system_status": "System Idle",
+            "operating_state": "idle"
+         },
+         {
+            "name": "connection",
+            "signal_strength": "unknown",
+            "is_connected": true
+         },
+         {
+            "name": "dealer_contact_info",
+            "has_dealer_identifier": true,
+            "actions": {
+               "request_current_dealer_info": {
+                  "method": "GET",
+                  "href": "https://www.mynexia.com/mobile/dealers/7043919191"
+               },
+               "request_dealers_by_zip": {
+                  "method": "POST",
+                  "href": "https://www.mynexia.com/mobile/dealers/5378307/search"
+               }
+            }
+         },
+         {
+            "name": "thermostat_mode",
+            "label": "System Mode",
+            "value": "HEAT",
+            "display_value": "Heating",
+            "options": [
+               {
+                  "id": "thermostat_mode",
+                  "label": "System Mode",
+                  "value": "thermostat_mode",
+                  "header": true
+               },
+               {
+                  "value": "AUTO",
+                  "label": "Auto"
+               },
+               {
+                  "value": "COOL",
+                  "label": "Cooling"
+               },
+               {
+                  "value": "HEAT",
+                  "label": "Heating"
+               },
+               {
+                  "value": "OFF",
+                  "label": "Off"
+               }
+            ],
+            "actions": {
+               "update_thermostat_mode": {
+                  "method": "POST",
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/zone_mode"
+               }
+            }
+         },
+         {
+            "name": "thermostat_run_mode",
+            "label": "Run Mode",
+            "options": [
+               {
+                  "id": "thermostat_run_mode",
+                  "label": "Run Mode",
+                  "value": "thermostat_run_mode",
+                  "header": true
+               },
+               {
+                  "id": "info_text",
+                  "label": "Follow or override the schedule.",
+                  "value": "info_text",
+                  "info": true
+               },
+               {
+                  "value": "permanent_hold",
+                  "label": "Permanent Hold"
+               },
+               {
+                  "value": "run_schedule",
+                  "label": "Run Schedule"
+               }
+            ],
+            "value": "run_schedule",
+            "display_value": "Run Schedule",
+            "actions": {
+               "update_thermostat_run_mode": {
+                  "method": "POST",
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/run_mode"
+               }
+            }
+         },
+         {
+            "name": "room_iq_sensors",
+            "sensors": [
+               {
+                  "id": 17687546,
+                  "name": "Center",
+                  "icon": {
+                     "name": "room_iq_onboard",
+                     "modifiers": []
+                  },
+                  "type": "thermostat",
+                  "serial_number": "NativeIDTUniqueID",
+                  "weight": 0.5,
+                  "temperature": 69,
+                  "temperature_valid": true,
+                  "humidity": 33,
+                  "humidity_valid": true,
+                  "has_online": false,
+                  "has_battery": false
+               },
+               {
+                  "id": 17687549,
+                  "name": "Upstairs",
+                  "icon": {
+                     "name": "room_iq_wireless",
+                     "modifiers": []
+                  },
+                  "type": "930",
+                  "serial_number": "2410R5C53X",
+                  "weight": 0.5,
+                  "temperature": 70,
+                  "temperature_valid": true,
+                  "humidity": 33,
+                  "humidity_valid": true,
+                  "has_online": true,
+                  "connected": true,
+                  "has_battery": true,
+                  "battery_level": 95,
+                  "battery_low": false,
+                  "battery_valid": true
+               }
+            ],
+            "should_show": true,
+            "actions": {
+               "request_current_state": {
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state"
+               },
+               "update_active_sensors": {
+                  "method": "POST",
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/update_active_sensors"
+               }
+            }
+         },
+         {
+            "name": "preset_setpoints",
+            "presets": {
+               "1": {
+                  "cool": 78,
+                  "heat": 70
+               },
+               "2": {
+                  "cool": 85,
+                  "heat": 62
+               },
+               "3": {
+                  "cool": 82,
+                  "heat": 62
+               }
+            }
+         },
+         {
+            "name": "thermostat_fan_mode",
+            "label": "Fan Mode",
+            "options": [
+               {
+                  "id": "thermostat_fan_mode",
+                  "label": "Fan Mode",
+                  "value": "thermostat_fan_mode",
+                  "header": true
+               },
+               {
+                  "value": "auto",
+                  "label": "Auto"
+               },
+               {
+                  "value": "on",
+                  "label": "On"
+               },
+               {
+                  "value": "circulate",
+                  "label": "Circulate"
+               }
+            ],
+            "value": "circulate",
+            "display_value": "Circulate",
+            "status_icon": {
+               "name": "thermostat_fan_off",
+               "modifiers": []
+            },
+            "actions": {
+               "update_thermostat_fan_mode": {
+                  "method": "POST",
+                  "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/fan_mode"
+               }
+            }
+         },
+         {
+            "name": "thermostat_default_fan_mode",
+            "value": "circulate",
+            "actions": {
+               "update_thermostat_default_fan_mode": {
+                  "method": "POST",
+                  "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/fan_mode"
+               }
+            }
+         },
+         {
+            "name": "gen_2_app",
+            "is_supported": false,
+            "validation_failures": [
+               "Thermostat has wireless sensors.",
+               "Unauthorized to use Gen 2 App."
+            ]
+         },
+         {
+            "name": "schedule",
+            "enabled": true,
+            "max_period_name_length": 10,
+            "setpoint_increment": 1.0,
+            "collection_url": "https://www.mynexia.com/mobile/schedules?device_identifier=TraneXl1050-5378307\u0026house_id=2582941",
+            "actions": {
+               "get_active_schedule": {
+                  "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_active_schedule?device_identifier=TraneXl1050-5378307",
+                  "method": "POST"
+               },
+               "set_active_schedule": {
+                  "href": "https://www.mynexia.com/mobile/thermostat_schedules/set_active_schedule?device_identifier=TraneXl1050-5378307",
+                  "method": "POST"
+               },
+               "get_default_schedule": {
+                  "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_default_schedule?device_identifier=TraneXl1050-5378307",
+                  "method": "GET"
+               },
+               "enable_scheduling": {
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/scheduling_enabled",
+                  "method": "POST",
+                  "data": {
+                     "value": true
+                  }
+               }
+            },
+            "can_add_remove_periods": true,
+            "max_periods_per_day": 4
+         },
+         {
+            "name": "runtime_history",
+            "actions": {
+               "get_runtime_history": {
+                  "method": "GET",
+                  "href": "https://www.mynexia.com/mobile/runtime_history/TraneXl1050-5378307?report_type=daily"
+               },
+               "get_monthly_runtime_history": {
+                  "method": "GET",
+                  "href": "https://www.mynexia.com/mobile/runtime_history/TraneXl1050-5378307?report_type=monthly"
+               }
+            }
+         }
+      ],
+      "icon": [
+         {
+            "name": "thermostat",
+            "modifiers": [
+               "temperature-69"
+            ]
+         }
+      ],
+      "_links": {
+         "self": {
+            "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307"
+         },
+         "nexia:history": {
+            "href": "https://www.mynexia.com/mobile/houses/2582941/events?device_id=5378307"
+         },
+         "filter_events": {
+            "href": "https://www.mynexia.com/mobile/houses/2582941/events/collection?sys_guid=e16684f6-b1e3-4e25-b006-e4d599dab2e9"
+         }
+      },
+      "last_updated_at": "2025-01-06T17:45:09.000-05:00",
+      "settings": [
+         {
+            "type": "preset_selected",
+            "title": "Preset",
+            "current_value": 0,
+            "options": [
+               {
+                  "value": 0,
+                  "label": "None"
+               },
+               {
+                  "value": 1,
+                  "label": "Home"
+               },
+               {
+                  "value": 2,
+                  "label": "Away"
+               },
+               {
+                  "value": 3,
+                  "label": "Sleep"
+               }
+            ],
+            "labels": [
+               "None",
+               "Home",
+               "Away",
+               "Sleep"
+            ],
+            "values": [
+               0,
+               1,
+               2,
+               3
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/preset_selected"
+               }
+            }
+         },
+         {
+            "type": "system_mode",
+            "title": "System Mode",
+            "current_value": "HEAT",
+            "options": [
+               {
+                  "value": "AUTO",
+                  "label": "Auto"
+               },
+               {
+                  "value": "COOL",
+                  "label": "Cooling"
+               },
+               {
+                  "value": "HEAT",
+                  "label": "Heating"
+               },
+               {
+                  "value": "OFF",
+                  "label": "Off"
+               }
+            ],
+            "labels": [
+               "Auto",
+               "Cooling",
+               "Heating",
+               "Off"
+            ],
+            "values": [
+               "AUTO",
+               "COOL",
+               "HEAT",
+               "OFF"
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/zone_mode"
+               }
+            }
+         },
+         {
+            "type": "run_mode",
+            "title": "Run Mode",
+            "current_value": "run_schedule",
+            "options": [
+               {
+                  "value": "permanent_hold",
+                  "label": "Permanent Hold"
+               },
+               {
+                  "value": "run_schedule",
+                  "label": "Run Schedule"
+               }
+            ],
+            "labels": [
+               "Permanent Hold",
+               "Run Schedule"
+            ],
+            "values": [
+               "permanent_hold",
+               "run_schedule"
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/run_mode"
+               }
+            }
+         },
+         {
+            "type": "scheduling_enabled",
+            "title": "Scheduling",
+            "current_value": true,
+            "options": [
+               {
+                  "value": true,
+                  "label": "ON"
+               },
+               {
+                  "value": false,
+                  "label": "OFF"
+               }
+            ],
+            "labels": [
+               "ON",
+               "OFF"
+            ],
+            "values": [
+               true,
+               false
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/scheduling_enabled"
+               }
+            }
+         },
+         {
+            "type": "fan_mode",
+            "title": "Fan Mode",
+            "current_value": "circulate",
+            "options": [
+               {
+                  "value": "auto",
+                  "label": "Auto"
+               },
+               {
+                  "value": "on",
+                  "label": "On"
+               },
+               {
+                  "value": "circulate",
+                  "label": "Circulate"
+               }
+            ],
+            "labels": [
+               "Auto",
+               "On",
+               "Circulate"
+            ],
+            "values": [
+               "auto",
+               "on",
+               "circulate"
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/fan_mode"
+               }
+            }
+         },
+         {
+            "type": "fan_circulation_time",
+            "title": "Fan Circulation Time",
+            "current_value": 10,
+            "options": [
+               {
+                  "value": 10,
+                  "label": "10 minutes"
+               },
+               {
+                  "value": 15,
+                  "label": "15 minutes"
+               },
+               {
+                  "value": 20,
+                  "label": "20 minutes"
+               },
+               {
+                  "value": 25,
+                  "label": "25 minutes"
+               },
+               {
+                  "value": 30,
+                  "label": "30 minutes"
+               },
+               {
+                  "value": 35,
+                  "label": "35 minutes"
+               },
+               {
+                  "value": 40,
+                  "label": "40 minutes"
+               },
+               {
+                  "value": 45,
+                  "label": "45 minutes"
+               },
+               {
+                  "value": 50,
+                  "label": "50 minutes"
+               },
+               {
+                  "value": 55,
+                  "label": "55 minutes"
+               }
+            ],
+            "labels": [
+               "10 minutes",
+               "15 minutes",
+               "20 minutes",
+               "25 minutes",
+               "30 minutes",
+               "35 minutes",
+               "40 minutes",
+               "45 minutes",
+               "50 minutes",
+               "55 minutes"
+            ],
+            "values": [
+               10,
+               15,
+               20,
+               25,
+               30,
+               35,
+               40,
+               45,
+               50,
+               55
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/fan_circulation_time"
+               }
+            }
+         },
+         {
+            "type": "air_cleaner_mode",
+            "title": "Air Cleaner Mode",
+            "current_value": "auto",
+            "options": [
+               {
+                  "value": "auto",
+                  "label": "Auto"
+               },
+               {
+                  "value": "quick",
+                  "label": "Quick"
+               },
+               {
+                  "value": "allergy",
+                  "label": "Allergy"
+               }
+            ],
+            "labels": [
+               "Auto",
+               "Quick",
+               "Allergy"
+            ],
+            "values": [
+               "auto",
+               "quick",
+               "allergy"
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/air_cleaner_mode"
+               }
+            }
+         },
+         {
+            "type": "dehumidify",
+            "title": "Cooling Dehumidify Set Point",
+            "current_value": 0.5,
+            "options": [
+               {
+                  "value": 0.35,
+                  "label": "35%"
+               },
+               {
+                  "value": 0.4,
+                  "label": "40%"
+               },
+               {
+                  "value": 0.45,
+                  "label": "45%"
+               },
+               {
+                  "value": 0.5,
+                  "label": "50%"
+               },
+               {
+                  "value": 0.55,
+                  "label": "55%"
+               },
+               {
+                  "value": 0.6,
+                  "label": "60%"
+               },
+               {
+                  "value": 0.65,
+                  "label": "65%"
+               }
+            ],
+            "labels": [
+               "35%",
+               "40%",
+               "45%",
+               "50%",
+               "55%",
+               "60%",
+               "65%"
+            ],
+            "values": [
+               0.35,
+               0.4,
+               0.45,
+               0.5,
+               0.55,
+               0.6,
+               0.65
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/dehumidify"
+               }
+            }
+         },
+         {
+            "type": "emergency_heat",
+            "title": "Emergency Heat",
+            "current_value": false,
+            "options": [
+               {
+                  "value": true,
+                  "label": "ON"
+               },
+               {
+                  "value": false,
+                  "label": "OFF"
+               }
+            ],
+            "labels": [
+               "ON",
+               "OFF"
+            ],
+            "values": [
+               true,
+               false
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/emergency_heat"
+               }
+            }
+         },
+         {
+            "type": "scale",
+            "title": "Temperature Scale",
+            "current_value": "f",
+            "options": [
+               {
+                  "value": "f",
+                  "label": "F"
+               },
+               {
+                  "value": "c",
+                  "label": "C"
+               }
+            ],
+            "labels": [
+               "F",
+               "C"
+            ],
+            "values": [
+               "f",
+               "c"
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_thermostats/5378307/scale"
+               }
+            }
+         }
+      ],
+      "status_secondary": null,
+      "status_tertiary": null,
+      "type": "xxl_thermostat",
+      "has_outdoor_temperature": true,
+      "outdoor_temperature": "39",
+      "has_indoor_humidity": true,
+      "connected": true,
+      "indoor_humidity": "33",
+      "system_status": "System Idle",
+      "delta": 3,
+      "manufacturer": "AmericanStandard",
+      "country_code": "US",
+      "state_code": "NC",
+      "zones": [
+         {
+            "type": "xxl_zone",
+            "id": 85034552,
+            "name": "NativeZone",
+            "current_zone_mode": "HEAT",
+            "temperature": 69,
+            "setpoints": {
+               "heat": 69,
+               "cool": null
+            },
+            "operating_state": "",
+            "heating_setpoint": 69,
+            "cooling_setpoint": null,
+            "zone_status": "",
+            "settings": [],
+            "icon": {
+               "name": "thermostat",
+               "modifiers": [
+                  "temperature-69"
+               ]
+            },
+            "features": [
+               {
+                  "name": "thermostat",
+                  "scale": "f",
+                  "temperature": 69,
+                  "device_identifier": "XxlZone-85034552",
+                  "status": "",
+                  "status_icon": null,
+                  "actions": {
+                     "set_heat_setpoint": {
+                        "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/setpoints"
+                     }
+                  },
+                  "setpoint_delta": 3,
+                  "setpoint_increment": 1.0,
+                  "setpoint_heat_min": 55,
+                  "setpoint_heat_max": 90,
+                  "setpoint_cool_min": 60,
+                  "setpoint_cool_max": 99,
+                  "setpoint_heat": 69,
+                  "system_status": "System Idle"
+               },
+               {
+                  "name": "connection",
+                  "signal_strength": "unknown",
+                  "is_connected": true
+               },
+               {
+                  "name": "dealer_contact_info",
+                  "has_dealer_identifier": true,
+                  "actions": {
+                     "request_current_dealer_info": {
+                        "method": "GET",
+                        "href": "https://www.mynexia.com/mobile/dealers/7043919191"
+                     },
+                     "request_dealers_by_zip": {
+                        "method": "POST",
+                        "href": "https://www.mynexia.com/mobile/dealers/5378307/search"
+                     }
+                  }
+               },
+               {
+                  "name": "thermostat_mode",
+                  "label": "System Mode",
+                  "value": "HEAT",
+                  "display_value": "Heating",
+                  "options": [
+                     {
+                        "id": "thermostat_mode",
+                        "label": "System Mode",
+                        "value": "thermostat_mode",
+                        "header": true
+                     },
+                     {
+                        "value": "AUTO",
+                        "label": "Auto"
+                     },
+                     {
+                        "value": "COOL",
+                        "label": "Cooling"
+                     },
+                     {
+                        "value": "HEAT",
+                        "label": "Heating"
+                     },
+                     {
+                        "value": "OFF",
+                        "label": "Off"
+                     }
+                  ],
+                  "actions": {
+                     "update_thermostat_mode": {
+                        "method": "POST",
+                        "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/zone_mode"
+                     }
+                  }
+               },
+               {
+                  "name": "thermostat_run_mode",
+                  "label": "Run Mode",
+                  "options": [
+                     {
+                        "id": "thermostat_run_mode",
+                        "label": "Run Mode",
+                        "value": "thermostat_run_mode",
+                        "header": true
+                     },
+                     {
+                        "id": "info_text",
+                        "label": "Follow or override the schedule.",
+                        "value": "info_text",
+                        "info": true
+                     },
+                     {
+                        "value": "permanent_hold",
+                        "label": "Permanent Hold"
+                     },
+                     {
+                        "value": "run_schedule",
+                        "label": "Run Schedule"
+                     }
+                  ],
+                  "value": "run_schedule",
+                  "display_value": "Run Schedule",
+                  "actions": {
+                     "update_thermostat_run_mode": {
+                        "method": "POST",
+                        "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/run_mode"
+                     }
+                  }
+               },
+               {
+                  "name": "room_iq_sensors",
+                  "sensors": [
+                     {
+                        "id": 17687546,
+                        "name": "Center",
+                        "icon": {
+                           "name": "room_iq_onboard",
+                           "modifiers": []
+                        },
+                        "type": "thermostat",
+                        "serial_number": "NativeIDTUniqueID",
+                        "weight": 0.5,
+                        "temperature": 69,
+                        "temperature_valid": true,
+                        "humidity": 33,
+                        "humidity_valid": true,
+                        "has_online": false,
+                        "has_battery": false
+                     },
+                     {
+                        "id": 17687549,
+                        "name": "Upstairs",
+                        "icon": {
+                           "name": "room_iq_wireless",
+                           "modifiers": []
+                        },
+                        "type": "930",
+                        "serial_number": "2410R5C53X",
+                        "weight": 0.5,
+                        "temperature": 70,
+                        "temperature_valid": true,
+                        "humidity": 33,
+                        "humidity_valid": true,
+                        "has_online": true,
+                        "connected": true,
+                        "has_battery": true,
+                        "battery_level": 95,
+                        "battery_low": false,
+                        "battery_valid": true
+                     }
+                  ],
+                  "should_show": true,
+                  "actions": {
+                     "request_current_state": {
+                        "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state"
+                     },
+                     "update_active_sensors": {
+                        "method": "POST",
+                        "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/update_active_sensors"
+                     }
+                  }
+               },
+               {
+                  "name": "preset_setpoints",
+                  "presets": {
+                     "1": {
+                        "cool": 78,
+                        "heat": 70
+                     },
+                     "2": {
+                        "cool": 85,
+                        "heat": 62
+                     },
+                     "3": {
+                        "cool": 82,
+                        "heat": 62
+                     }
+                  }
+               },
+               {
+                  "name": "schedule",
+                  "enabled": true,
+                  "max_period_name_length": 10,
+                  "setpoint_increment": 1.0,
+                  "collection_url": "https://www.mynexia.com/mobile/schedules?device_identifier=XxlZone-85034552\u0026house_id=2582941",
+                  "actions": {
+                     "get_active_schedule": {
+                        "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_active_schedule?device_identifier=XxlZone-85034552",
+                        "method": "POST"
+                     },
+                     "set_active_schedule": {
+                        "href": "https://www.mynexia.com/mobile/thermostat_schedules/set_active_schedule?device_identifier=XxlZone-85034552",
+                        "method": "POST"
+                     },
+                     "get_default_schedule": {
+                        "href": "https://www.mynexia.com/mobile/thermostat_schedules/get_default_schedule?device_identifier=XxlZone-85034552",
+                        "method": "GET"
+                     },
+                     "enable_scheduling": {
+                        "href": "https://www.mynexia.com/mobile/xxl_zones/85034552/scheduling_enabled",
+                        "method": "POST",
+                        "data": {
+                           "value": true
+                        }
+                     }
+                  },
+                  "can_add_remove_periods": true,
+                  "max_periods_per_day": 4
+               }
+            ],
+            "_links": {
+               "self": {
+                  "href": "https://www.mynexia.com/mobile/xxl_zones/85034552"
+               }
+            }
+         }
+      ],
+      "generic_input_sensors": []
+   }
+}

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1042,8 +1042,8 @@ async def test_emergency_heat(aiohttp_session):
 async def test_sensor_access(mock_aioresponse: aioresponses):
     """Test sensor access methods."""
     async with aiohttp.ClientSession() as aiohttp_session:
-        state_file = Path("nexia_config_test.conf")
-        nexia = NexiaHome(aiohttp_session, house_id=2582941, state_file=state_file)
+        persist_file = Path("nexia_config_test.conf")
+        nexia = NexiaHome(aiohttp_session, house_id=2582941, state_file=persist_file)
         mock_aioresponse.post(
             "https://www.mynexia.com/mobile/accounts/sign_in",
             payload={
@@ -1097,7 +1097,7 @@ async def test_sensor_access(mock_aioresponse: aioresponses):
         assert sensor.humidity == 32
         assert sensor.humidity_valid is True
         assert sensor.has_battery is True
-        assert sensor.battery_level is 95
+        assert sensor.battery_level == 95
         assert sensor.battery_valid is True
 
         mock_aioresponse.post(
@@ -1145,6 +1145,6 @@ async def test_sensor_access(mock_aioresponse: aioresponses):
         assert sensor.temperature == 70
         assert sensor.humidity == 33
 
-    assert state_file.exists() is True
-    state_file.unlink()
-    assert state_file.exists() is False
+    assert persist_file.exists() is True
+    persist_file.unlink()
+    assert persist_file.exists() is False

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -913,7 +913,6 @@ async def test_new_xl824(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-
 async def test_system_offline(aiohttp_session):
     """Get a system offline."""
     nexia = NexiaHome(aiohttp_session)
@@ -965,7 +964,6 @@ async def test_system_offline(aiohttp_session):
     assert zone.is_in_permanent_hold() is True
 
 
-
 async def test_emergency_heat(aiohttp_session):
     """Test emergency heat."""
     nexia = NexiaHome(aiohttp_session)
@@ -1004,7 +1002,7 @@ async def test_emergency_heat(aiohttp_session):
     assert zone_ids == [84326108]
     zone = thermostat.get_zone_by_id(84326108)
 
-    assert zone.get_name() ==  'XL850 Home NativeZone'
+    assert zone.get_name() == 'XL850 Home NativeZone'
     assert zone.get_cooling_setpoint() == 99
     assert zone.get_heating_setpoint() == 68
     assert zone.get_current_mode() == "HEAT"

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -3,6 +3,8 @@
 import json
 import os
 from os.path import dirname
+from pathlib import Path
+
 from aioresponses import aioresponses
 import pytest
 import aiohttp
@@ -151,7 +153,7 @@ async def test_idle_thermo_issue_33758(mock_aioresponse: aioresponses):
 
 
 async def test_idle_thermo_issue_33968_thermostat_1690380(aiohttp_session):
-    """Get methods for an cooling thermostat."""
+    """Get methods for a cooling thermostat."""
     nexia = NexiaHome(aiohttp_session)
     devices_json = json.loads(await load_fixture("mobile_house_issue_33968.json"))
     nexia.update_from_json(devices_json)
@@ -854,12 +856,33 @@ async def test_new_xl1050(aiohttp_session):
     assert zone.get_heating_setpoint() == 55
     assert zone.get_current_mode() == "COOL"
     assert zone.get_requested_mode() == "COOL"
+    assert zone.get_temperature() == 72
     assert zone.get_presets() == ["None", "Home", "Away", "Sleep"]
     assert zone.get_preset() == "None"
     assert zone.get_status() == "Idle"
     assert zone.get_setpoint_status() == "Run Schedule - None"
     assert zone.is_calling() is False
+    assert zone.check_heat_cool_setpoints(70, 76) is None
     assert zone.is_in_permanent_hold() is False
+
+    # Sensors
+    thermostat = nexia.get_thermostat_by_id(2059676)
+
+    assert thermostat.get_zone_ids() == [83261015, 83261018, 84243806, 83535112]
+    zone = thermostat.get_zone_by_id(83261015)
+    sensors = zone.get_sensors()
+
+    assert len(sensors) == 1
+    sensor = sensors[0]
+    assert sensor.id == 16800389
+    assert sensor.name == "Living West"
+    assert sensor.type == "thermostat"
+    assert sensor.serial_number == "NativeIDTUniqueID"
+    assert sensor.weight == 1.0
+    assert sensor.temperature == 70
+    assert sensor.temperature_valid is True
+    assert sensor.humidity == 42
+    assert sensor.humidity_valid is True
 
 
 async def test_new_xl824(aiohttp_session):
@@ -1013,3 +1036,108 @@ async def test_emergency_heat(aiohttp_session):
     assert zone.get_setpoint_status() == "Run Schedule - None"
     assert zone.is_calling() is True
     assert zone.is_in_permanent_hold() is False
+
+
+async def test_sensor_access(mock_aioresponse: aioresponses):
+    """Test sensor access methods."""
+    async with aiohttp.ClientSession() as aiohttp_session:
+        state_file = Path("nexia_config_test.conf")
+        nexia = NexiaHome(aiohttp_session, house_id=2582941, state_file=state_file)
+        mock_aioresponse.post(
+            "https://www.mynexia.com/mobile/accounts/sign_in",
+            payload={
+                "success": True,
+                "error": None,
+                "result": {
+                    "mobile_id": 5400000,
+                    "api_key": "10654c0be00000000000000000000000",
+                    "setup_step": "done",
+                    "locale": "en_us"
+                }
+            },
+        )
+        await nexia.login()
+        mock_aioresponse.get(
+            "https://www.mynexia.com/mobile/houses/2582941",
+            body=await load_fixture("sensors_xl1050_house.json"),
+        )
+        assert await nexia.update() is not None
+
+        assert nexia.get_thermostat_ids() == [5378307]
+        thermostat: NexiaThermostat = nexia.get_thermostat_by_id(5378307)
+
+        assert thermostat.get_zone_ids() == [85034552]
+        zone = thermostat.get_zone_by_id(85034552)
+        sensors = zone.get_sensors()
+
+        assert len(sensors) == 2
+        sensor = sensors[0]
+        assert sensor.id == 17687546
+        assert sensor.name == "Center"
+        assert sensor.type == "thermostat"
+        assert sensor.serial_number == "NativeIDTUniqueID"
+        assert sensor.weight == 0.5
+        assert sensor.temperature == 68
+        assert sensor.temperature_valid is True
+        assert sensor.humidity == 32
+        assert sensor.humidity_valid is True
+
+        sensor = sensors[1]
+        assert sensor.id == 17687549
+        assert sensor.name == "Upstairs"
+        assert sensor.type == "930"
+        assert sensor.serial_number == "2410R5C53X"
+        assert sensor.weight == 0.5
+        assert sensor.temperature == 69
+        assert sensor.temperature_valid is True
+        assert sensor.humidity == 32
+        assert sensor.humidity_valid is True
+
+        mock_aioresponse.post(
+            "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state",
+            payload={
+                "success": True,
+                "error": None,
+                "result": {
+                    "polling_path": "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa5dd381e5"
+                }
+            },
+        )
+        mock_aioresponse.get(
+            "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa5dd381e5",
+            body=b"null",
+        )
+        mock_aioresponse.get(
+            "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa5dd381e5",
+            payload={
+                "status": "success, altered to enhance test coverage",
+                "options": {}
+            },
+        )
+        assert await zone.load_current_sensor_state(0.01) is True
+
+        mock_aioresponse.get(
+            "https://www.mynexia.com/mobile/xxl_thermostats/5378307",
+            body=await load_fixture("sensors_xl1050_thermostat.json"),
+        )
+        await thermostat.refresh_thermostat_data()
+        sensors = zone.get_sensors()
+
+        assert len(sensors) == 2
+        sensor = sensors[0]
+        assert sensor.id == 17687546
+        assert sensor.name == "Center"
+        assert sensor.weight == 0.5
+        assert sensor.temperature == 69
+        assert sensor.humidity == 33
+
+        sensor = sensors[1]
+        assert sensor.id == 17687549
+        assert sensor.name == "Upstairs"
+        assert sensor.weight == 0.5
+        assert sensor.temperature == 70
+        assert sensor.humidity == 33
+
+    assert state_file.exists() is True
+    state_file.unlink()
+    assert state_file.exists() is False

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -883,6 +883,7 @@ async def test_new_xl1050(aiohttp_session):
     assert sensor.temperature_valid is True
     assert sensor.humidity == 42
     assert sensor.humidity_valid is True
+    assert sensor.has_battery is False
 
 
 async def test_new_xl824(aiohttp_session):
@@ -1081,6 +1082,9 @@ async def test_sensor_access(mock_aioresponse: aioresponses):
         assert sensor.temperature_valid is True
         assert sensor.humidity == 32
         assert sensor.humidity_valid is True
+        assert sensor.has_battery is False
+        assert sensor.battery_level is None
+        assert sensor.battery_valid is None
 
         sensor = sensors[1]
         assert sensor.id == 17687549
@@ -1092,6 +1096,9 @@ async def test_sensor_access(mock_aioresponse: aioresponses):
         assert sensor.temperature_valid is True
         assert sensor.humidity == 32
         assert sensor.humidity_valid is True
+        assert sensor.has_battery is True
+        assert sensor.battery_level is 95
+        assert sensor.battery_valid is True
 
         mock_aioresponse.post(
             "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state",

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ ignore_errors = True
 commands =
      flake8 nexia
      pylint nexia
-     mypy nexia
+     mypy --check-untyped-defs nexia
 
 [flake8]
 max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -33,3 +33,7 @@ commands =
 
 [flake8]
 max-line-length = 120
+
+[pytest]
+asyncio_default_fixture_loop_scope = session
+asyncio_mode = auto


### PR DESCRIPTION
This pull has changes to obtain sensor details in a Nexia Thermostat environment. The sensor data loaded during Nexia Home update are often out of date. So the Nexia Thermostat Zone service load_current_sensor_state is provided to load current sensor state into the physical thermostat. Many existing thermostat instance services will refresh this sensor data before completing. If none are needed, Nexia Thermostat service refresh_thermostat_data is provided to refresh instance data. The Nexia Thermostat Zone service get_sensors is provided to obtain these sensor data in a list of sensor detail data objects of type NexiaSensor.